### PR TITLE
Disable readOnlyRootFilesystem for config.json ENV vars

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dependency-track
-version: 0.1.0
+version: 0.1.1
 type: application
 appVersion: 4.10.1
 home: https://github.com/DependencyTrack/dependency-track

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false # RO filesystems are not supported by the frontend
           seccompProfile:
             type: RuntimeDefault
         {{- with .Values.frontend.command }}


### PR DESCRIPTION
For the ENV variables to work, config.json must be writable on the filesystem.

This is because [30-oidc-configruation.sh](https://github.com/DependencyTrack/frontend/blob/master/docker/docker-entrypoint.d/30-oidc-configuration.sh) writes to this file to set the configuration. Without this change, the ENV configuration is ignored.