### PR TITLE
Generate release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+  - title: Enhancements 🚀
+    labels:
+    - enhancement
+  - title: Bug Fixes 🐛
+    labels:
+    - defect
+  - title: Dependency Updates 🤖
+    labels:
+    - dependencies
+  - title: Other Changes
+    labels:
+    - "*"

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -29,4 +29,4 @@ jobs:
       env:
         CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       with:
-        skip_existing: true
+        config: cr.yaml

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,2 @@
+generate-release-notes: true
+skip-existing: true


### PR DESCRIPTION
Currently, the release description only contains the description of the Chart being released, which is not helpful at all for users.

Use the GitHub-generated release notes instead.