### PR TITLE
add node-selector to helm chart

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dependency-track
-version: 0.3.0
+version: 0.3.1
 type: application
 appVersion: 4.10.1
 description: |-

--- a/charts/dependency-track/templates/api-server/statefulset.yaml
+++ b/charts/dependency-track/templates/api-server/statefulset.yaml
@@ -106,6 +106,10 @@ spec:
       tolerations:
       {{- toYaml .Values.apiServer.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.apiServer.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.apiServer.nodeSelector | nindent 8 }}
+      {{- end }}
       volumes:
       {{- if not .Values.apiServer.persistentVolume.enabled }}
       - name: data

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -91,6 +91,10 @@ spec:
       tolerations:
       {{- toYaml .Values.frontend.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.frontend.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.frontend.nodeSelector | nindent 8 }}
+      {{- end }}
       volumes:
       - name: tmp
         emptyDir: { }

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -64,6 +64,7 @@ apiServer:
     scrapeInternal: 15s
     scrapeTimeout: 30s
   initContainers: []
+  nodeSelector: {}
   # Use the following to fix permissions on the /data volume.
   # initContainers:
   #   - name: fix-permissions
@@ -132,6 +133,7 @@ frontend:
     annotations: {}
   apiBaseUrl: ""
   initContainers: []
+  nodeSelector: {}
 
 ingress:
   enabled: false
@@ -144,8 +146,7 @@ ingress:
   #      - example.com
 
 # -- Create extra manifests via values.
-extraObjects:
-  []
+extraObjects: []
   # - apiVersion: "kubernetes-client.io/v1"
   #   kind: ExternalSecret
   #   metadata:


### PR DESCRIPTION
🛠 Helm Chart Enhancement
- Adds `nodeSelector` label to helm chart

🧪 How to Test
Deploy and Validate: Deploy the updated chart in a controlled environment. Validate all new functionalities. This change is non-breaking and backwards compatible.

Closes https://github.com/DependencyTrack/helm-charts/issues/40