### PR TITLE
Bump `appVersion` to `4.11.0`

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dependency-track
-version: 0.3.1
+version: 0.4.0
 type: application
-appVersion: 4.10.1
+appVersion: 4.11.0
 description: |-
   Dependency-Track is an intelligent Component Analysis platform
   that allows organizations to identify and reduce risk in the software supply chain.

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -91,7 +91,7 @@ frontend:
   annotations: {}
   image:
     repository: dependencytrack/frontend
-    tag: 4.10.0
+    tag: ~
     pullPolicy: IfNotPresent
   command: []
   args: []


### PR DESCRIPTION
Also removes the default override for `frontend.image.tag`, now that API server and frontend both use the same version.