### PR TITLE
Disable version increment check

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -1,2 +1,3 @@
 target-branch: main
 helm-extra-args: --timeout 60s
+check-version-increment: false


### PR DESCRIPTION
We don't trigger a release for every push to `main`, and it's a non-obvious requirement to contributors which just adds friction.

We'll manually bump the version prior to release.