### PR TITLE
Specify `envFrom` as `array` instead of `object` to support `valueFrom`

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dependency-track
-version: 0.8.0
+version: 0.9.0
 type: application
 appVersion: 4.11.3
 description: |-

--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -1,6 +1,6 @@
 # dependency-track
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.11.3](https://img.shields.io/badge/AppVersion-4.11.3-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.11.3](https://img.shields.io/badge/AppVersion-4.11.3-informational?style=flat-square)
 
 Dependency-Track is an intelligent Component Analysis platform
 that allows organizations to identify and reduce risk in the software supply chain.
@@ -27,7 +27,7 @@ that allows organizations to identify and reduce risk in the software supply cha
 | apiServer.args | list | `[]` |  |
 | apiServer.command | list | `[]` |  |
 | apiServer.extraContainers | list | `[]` |  |
-| apiServer.extraEnv | object | `{}` |  |
+| apiServer.extraEnv | list | `[]` |  |
 | apiServer.extraEnvFrom | list | `[]` |  |
 | apiServer.image.pullPolicy | string | `"IfNotPresent"` |  |
 | apiServer.image.repository | string | `"dependencytrack/apiserver"` |  |
@@ -77,7 +77,7 @@ that allows organizations to identify and reduce risk in the software supply cha
 | frontend.args | list | `[]` |  |
 | frontend.command | list | `[]` |  |
 | frontend.extraContainers | list | `[]` |  |
-| frontend.extraEnv | object | `{}` |  |
+| frontend.extraEnv | list | `[]` |  |
 | frontend.extraEnvFrom | list | `[]` |  |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | frontend.image.repository | string | `"dependencytrack/frontend"` |  |
@@ -108,4 +108,3 @@ that allows organizations to identify and reduce risk in the software supply cha
 | ingress.hostname | string | `"example.com"` |  |
 | ingress.ingressClassName | string | `""` |  |
 | ingress.tls | list | `[]` |  |
-

--- a/charts/dependency-track/ci/additional-pvc.yaml
+++ b/charts/dependency-track/ci/additional-pvc.yaml
@@ -11,7 +11,8 @@ apiServer:
       cpu: "2"
       memory: "512Mi"
   extraEnv:
-    SYSTEM_REQUIREMENT_CHECK_ENABLED: "false"
+    - name: SYSTEM_REQUIREMENT_CHECK_ENABLED
+      value: "false"
   additionalVolumeMounts:
     - name: foo
       mountPath: /bar

--- a/charts/dependency-track/ci/init-values.yaml
+++ b/charts/dependency-track/ci/init-values.yaml
@@ -11,7 +11,8 @@ apiServer:
       cpu: "2"
       memory: "512Mi"
   extraEnv:
-    SYSTEM_REQUIREMENT_CHECK_ENABLED: "false"
+    - name: SYSTEM_REQUIREMENT_CHECK_ENABLED
+      value: "false"
   initContainers:
     - name: fix-permissions
       image: docker.io/library/busybox

--- a/charts/dependency-track/ci/pvc-values.yaml
+++ b/charts/dependency-track/ci/pvc-values.yaml
@@ -14,4 +14,5 @@ apiServer:
     enabled: true
     size: "128Mi"
   extraEnv:
-    SYSTEM_REQUIREMENT_CHECK_ENABLED: "false"
+    - name: SYSTEM_REQUIREMENT_CHECK_ENABLED
+      value: "false"

--- a/charts/dependency-track/ci/test-values.yaml
+++ b/charts/dependency-track/ci/test-values.yaml
@@ -11,4 +11,5 @@ apiServer:
       cpu: "2"
       memory: "512Mi"
   extraEnv:
-    SYSTEM_REQUIREMENT_CHECK_ENABLED: "false"
+    - name: SYSTEM_REQUIREMENT_CHECK_ENABLED
+      value: "false"

--- a/charts/dependency-track/templates/api-server/statefulset.yaml
+++ b/charts/dependency-track/templates/api-server/statefulset.yaml
@@ -55,9 +55,8 @@ spec:
         - name: ALPINE_SECRET_KEY_PATH
           value: "/var/run/secrets/secret.key"
         {{- end }}
-        {{- range $k, $v := .Values.apiServer.extraEnv }}
-        - name: {{ $k }}
-          value: {{ $v | quote }}
+        {{- with .Values.apiServer.extraEnv }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.apiServer.extraEnvFrom }}
         envFrom: {{ toYaml . | nindent 8 }}

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -48,9 +48,8 @@ spec:
         env:
         - name: API_BASE_URL
           value: {{ .Values.frontend.apiBaseUrl | quote }}
-        {{- range $k, $v := .Values.frontend.extraEnv }}
-        - name: {{ $k }}
-          value: {{ $v | quote }}
+        {{- with .Values.apiServer.extraEnv }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- with .Values.frontend.extraEnvFrom }}
         envFrom: {{ toYaml . | nindent 8 }}

--- a/charts/dependency-track/values-minikube.yaml
+++ b/charts/dependency-track/values-minikube.yaml
@@ -13,8 +13,10 @@ apiServer:
     type: NodePort
     nodePort: 30080
   extraEnv:
-    EXTRA_JAVA_OPTIONS: "-Xmx2g"
-    SYSTEM_REQUIREMENT_CHECK_ENABLED: "false"
+    - name: EXTRA_JAVA_OPTIONS
+      value: "-Xmx2g"
+    - name: SYSTEM_REQUIREMENT_CHECK_ENABLED
+      value: "false"
 
 frontend:
   service:

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -38,7 +38,14 @@ apiServer:
     enabled: false
     className: ""
     size: 5Gi
-  extraEnv: {}
+  extraEnv: []
+    # - name: "ALPINE_DATABASE_PASSWORD"
+    #   valueFrom:
+    #     secretKeyRef:
+    #       key: db-password
+    #       name: dependencytrack-secrets
+    # - name: ALPINE_DATABASE_MODE
+    #   value: "external"
   extraEnvFrom: []
   extraContainers: []
   tolerations: []
@@ -110,7 +117,7 @@ frontend:
     limits:
       cpu: 500m
       memory: 128Mi
-  extraEnv: {}
+  extraEnv: []
   extraEnvFrom: []
   extraContainers: []
   tolerations: []


### PR DESCRIPTION
We might have values defined in custom secrets/configmaps This change enables this capability

Related issue #82 