### PR TITLE
Add PostgreSQL and Redpanda to `values-minikube.yaml`

### DIFF
--- a/charts/hyades/ci/test-values.yaml
+++ b/charts/hyades/ci/test-values.yaml
@@ -1,8 +1,8 @@
 common:
   database:
     jdbcUrl: "jdbc:postgresql://postgres.{{ .Release.Namespace }}.svc.cluster.local:5432/dtrack"
-    username: dtrack
-    password: dtrack
+    username: "dtrack"
+    password: "dtrack"
   kafka:
     bootstrapServers: "redpanda.{{ .Release.Namespace }}.svc.cluster.local:9092"
   secretKey:

--- a/charts/hyades/values-minikube.yaml
+++ b/charts/hyades/values-minikube.yaml
@@ -1,11 +1,11 @@
 ---
 common:
   database:
-    jdbcUrl: "jdbc:postgresql://host.minikube.internal:5432/dtrack"
+    jdbcUrl: "jdbc:postgresql://postgres.{{ .Release.Namespace }}.svc.cluster.local:5432/dtrack"
     username: "dtrack"
     password: "dtrack"
   kafka:
-    bootstrapServers: "host.minikube.internal:9093"
+    bootstrapServers: "redpanda.{{ .Release.Namespace }}.svc.cluster.local:9092"
   secretKey:
     createSecret: true
 
@@ -29,3 +29,143 @@ frontend:
     type: NodePort
     nodePort: 30081
   apiBaseUrl: "http://localhost:30080"
+
+extraObjects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: postgres
+    namespace: "{{ .Release.Namespace }}"
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+        app.kubernetes.io/name: "{{ printf \"%s-postgres\" (include \"hyades.name\" .) }}"
+        app.kubernetes.io/component: postgres
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/instance: "{{ .Release.Name }}"
+          app.kubernetes.io/name: "{{ printf \"%s-postgres\" (include \"hyades.name\" .) }}"
+          app.kubernetes.io/component: postgres
+      spec:
+        containers:
+        - name: postgres
+          image: postgres:16-alpine
+          env:
+          - name: POSTGRES_DB
+            value: dtrack
+          - name: POSTGRES_USER
+            value: dtrack
+          - name: POSTGRES_PASSWORD
+            value: dtrack
+          ports:
+          - name: postgres
+            containerPort: 5432
+            protocol: TCP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: postgres
+    namespace: "{{ .Release.Namespace }}"
+    labels:
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+      app.kubernetes.io/name: "{{ printf \"%s-postgres\" (include \"hyades.name\" .) }}"
+      app.kubernetes.io/component: postgres
+  spec:
+    type: ClusterIP
+    selector:
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+      app.kubernetes.io/name: "{{ printf \"%s-postgres\" (include \"hyades.name\" .) }}"
+      app.kubernetes.io/component: postgres
+    ports:
+    - port: 5432
+      targetPort: 5432
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: redpanda
+    namespace: "{{ .Release.Namespace }}"
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+        app.kubernetes.io/name: "{{ printf \"%s-redpanda\" (include \"hyades.name\" .) }}"
+        app.kubernetes.io/component: redpanda
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/instance: "{{ .Release.Name }}"
+          app.kubernetes.io/name: "{{ printf \"%s-redpanda\" (include \"hyades.name\" .) }}"
+          app.kubernetes.io/component: redpanda
+      spec:
+        containers:
+        - name: redpanda
+          image: docker.redpanda.com/vectorized/redpanda:v24.1.7
+          args:
+          - redpanda
+          - start
+          - --smp
+          - '1'
+          - --reserve-memory
+          - 0M
+          - --memory
+          - 512M
+          - --overprovisioned
+          - --node-id
+          - '0'
+          - --kafka-addr
+          - PLAINTEXT://0.0.0.0:9092
+          - --advertise-kafka-addr
+          - PLAINTEXT://redpanda.{{ .Release.Namespace }}.svc.cluster.local:9092
+        ports:
+        - name: kafka-api
+          containerPort: 9092
+          protocol: TCP
+        - name: redpanda-admin
+          containerPort: 9644
+          protocol: TCP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: redpanda
+    namespace: "{{ .Release.Namespace }}"
+    labels:
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+      app.kubernetes.io/name: "{{ printf \"%s-redpanda\" (include \"hyades.name\" .) }}"
+      app.kubernetes.io/component: redpanda
+  spec:
+    type: ClusterIP
+    selector:
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+      app.kubernetes.io/name: "{{ printf \"%s-redpanda\" (include \"hyades.name\" .) }}"
+      app.kubernetes.io/component: redpanda
+    ports:
+    - name: kafka-api
+      port: 9092
+      targetPort: 9092
+    - name: redpanda-admin
+      port: 9644
+      targetPort: 9644
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: redpanda-init
+    namespace: "{{ .Release.Namespace }}"
+  spec:
+    template:
+      spec:
+        containers:
+        - name: redpanda
+          image: docker.redpanda.com/vectorized/redpanda:v24.1.7
+          command:
+          - /bin/bash
+          args:
+          - -c
+          - bash <(curl -s https://raw.githubusercontent.com/DependencyTrack/hyades/main/scripts/create-topics.sh)
+          env:
+          - name: REDPANDA_BROKERS
+            value: "redpanda.{{ .Release.Namespace }}.svc.cluster.local:9092"
+        restartPolicy: OnFailure


### PR DESCRIPTION
This makes it easier to kick the tires with the `hyades` chart. Previously, running PostgreSQL and Kafka via Docker Compose was required.