### PR TITLE
Add registry override to apiServer and frontend

### DIFF
--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -30,6 +30,7 @@ that allows organizations to identify and reduce risk in the software supply cha
 | apiServer.extraEnv | list | `[]` |  |
 | apiServer.extraEnvFrom | list | `[]` |  |
 | apiServer.image.pullPolicy | string | `"IfNotPresent"` |  |
+| apiServer.image.registry | string | `""` | Override common registry |
 | apiServer.image.repository | string | `"dependencytrack/apiserver"` |  |
 | apiServer.image.tag | string | `nil` |  |
 | apiServer.initContainers | list | `[]` |  |
@@ -80,6 +81,7 @@ that allows organizations to identify and reduce risk in the software supply cha
 | frontend.extraEnv | list | `[]` |  |
 | frontend.extraEnvFrom | list | `[]` |  |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
+| frontend.image.registry  | string | `""` | Override common registry |
 | frontend.image.repository | string | `"dependencytrack/frontend"` |  |
 | frontend.image.tag | string | `nil` |  |
 | frontend.initContainers | list | `[]` |  |

--- a/charts/dependency-track/templates/_helpers.tpl
+++ b/charts/dependency-track/templates/_helpers.tpl
@@ -83,7 +83,7 @@ API server fully qualified name
 API server image
 */}}
 {{- define "dependencytrack.apiServerImage" -}}
-{{- printf "%s/%s:%s" .Values.common.image.registry .Values.apiServer.image.repository (.Values.apiServer.image.tag | default .Chart.AppVersion) -}}
+{{- printf "%s/%s:%s" (.Values.apiServer.image.registry | default .Values.common.image.registry) .Values.apiServer.image.repository (.Values.apiServer.image.tag | default .Chart.AppVersion) -}}
 {{- end -}}
 
 
@@ -123,7 +123,7 @@ Frontend fully qualified name
 Frontend image
 */}}
 {{- define "dependencytrack.frontendImage" -}}
-{{- printf "%s/%s:%s" .Values.common.image.registry .Values.frontend.image.repository (.Values.frontend.image.tag | default .Chart.AppVersion) -}}
+{{- printf "%s/%s:%s" (.Values.frontend.image.registry | default .Values.common.image.registry) .Values.frontend.image.repository (.Values.frontend.image.tag | default .Chart.AppVersion) -}}
 {{- end -}}
 
 {{/*

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -22,6 +22,7 @@ common:
 apiServer:
   annotations: {}
   image:
+    registry: ''
     repository: dependencytrack/apiserver
     tag: ~
     pullPolicy: IfNotPresent
@@ -105,6 +106,7 @@ frontend:
   replicaCount: 1
   annotations: {}
   image:
+    registry: ''
     repository: dependencytrack/frontend
     tag: ~
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Allow the common image registry to be overridden.

Because of the use of internal CAs, I need to rebuild the api server image.
Thus, it ends up in a different registry than the frontend image (which I don’t need to touch).

This PR enables the image registry to be changed for the api server and frontend independently and keeps the registry set in `.Values.common.image.registry` as default.

Known limitations:
Someone else might find it useful to also define per image pull secrets. I did not implement this, because I don’t have a good way to test it.
