### PR TITLE
Rename kafka topic prefix config for apache kafka compatibility

### DIFF
--- a/charts/hyades/templates/api-server/deployment.yaml
+++ b/charts/hyades/templates/api-server/deployment.yaml
@@ -75,7 +75,7 @@ spec:
         - name: KAFKA_BOOTSTRAP_SERVERS
           value: {{ tpl .Values.common.kafka.bootstrapServers $ | quote }}
         {{- with .Values.common.kafka.topicPrefix }}
-        - name: KAFKA_TOPIC_PREFIX
+        - name: DT_KAFKA_TOPIC_PREFIX
           value: {{ . | quote }}
         {{- end }}
         {{- with .Values.apiServer.extraEnv }}

--- a/charts/hyades/templates/mirror-service/deployment.yaml
+++ b/charts/hyades/templates/mirror-service/deployment.yaml
@@ -68,7 +68,7 @@ spec:
         - name: KAFKA_BOOTSTRAP_SERVERS
           value: {{ tpl .Values.common.kafka.bootstrapServers $ | quote }}
         {{- with .Values.common.kafka.topicPrefix }}
-        - name: KAFKA_TOPIC_PREFIX
+        - name: DT_KAFKA_TOPIC_PREFIX
           value: {{ . | quote }}
         {{- end }}
         {{- with .Values.mirrorService.extraEnv }}

--- a/charts/hyades/templates/notification-publisher/deployment.yaml
+++ b/charts/hyades/templates/notification-publisher/deployment.yaml
@@ -68,7 +68,7 @@ spec:
         - name: KAFKA_BOOTSTRAP_SERVERS
           value: {{ tpl .Values.common.kafka.bootstrapServers $ | quote }}
         {{- with .Values.common.kafka.topicPrefix }}
-        - name: KAFKA_TOPIC_PREFIX
+        - name: DT_KAFKA_TOPIC_PREFIX
           value: {{ . | quote }}
         {{- end }}
         {{- with .Values.notificationPublisher.extraEnv }}

--- a/charts/hyades/templates/repo-meta-analyzer/deployment.yaml
+++ b/charts/hyades/templates/repo-meta-analyzer/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         - name: KAFKA_BOOTSTRAP_SERVERS
           value: {{ tpl .Values.common.kafka.bootstrapServers $ | quote }}
         {{- with .Values.common.kafka.topicPrefix }}
-        - name: KAFKA_TOPIC_PREFIX
+        - name: DT_KAFKA_TOPIC_PREFIX
           value: {{ . | quote }}
         {{- end }}
         {{- with .Values.repoMetaAnalyzer.extraEnv }}

--- a/charts/hyades/templates/vuln-analyzer/statefulset.yaml
+++ b/charts/hyades/templates/vuln-analyzer/statefulset.yaml
@@ -71,7 +71,7 @@ spec:
         - name: KAFKA_STREAMS_STATE_DIR
           value: /var/lib/kafka-streams
         {{- with .Values.common.kafka.topicPrefix }}
-        - name: KAFKA_TOPIC_PREFIX
+        - name: DT_KAFKA_TOPIC_PREFIX
           value: {{ . | quote }}
         {{- end }}
         {{- with .Values.vulnAnalyzer.extraEnv }}


### PR DESCRIPTION
Creation of Kafka Streams repartition topics currently fails with Unknown topic config name: prefix, when using Apache Kafka instead of Redpanda.

Rename the prefix config to avoid the error.

Issue: https://github.com/DependencyTrack/hyades/issues/1392