### PR TITLE
Added conditional logic to Readiness and Liveness probes for apiServer

### DIFF
--- a/charts/dependency-track/templates/api-server/statefulset.yaml
+++ b/charts/dependency-track/templates/api-server/statefulset.yaml
@@ -84,7 +84,11 @@ spec:
           httpGet:
             scheme: HTTP
             port: web
+            {{- if ne .Values.apiServer.extraEnv.CONTEXT "/" }}
+            path: {{ .Values.apiServer.extraEnv.CONTEXT }}/health/live
+            {{- else }}
             path: /health/live
+            {{- end }}
           failureThreshold: {{ .Values.apiServer.probes.liveness.failureThreshold }}
           initialDelaySeconds: {{ .Values.apiServer.probes.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.apiServer.probes.liveness.periodSeconds }}
@@ -94,7 +98,11 @@ spec:
           httpGet:
             scheme: HTTP
             port: web
+            {{- if ne .Values.apiServer.extraEnv.CONTEXT "/" }}
+            path: {{ .Values.apiServer.extraEnv.CONTEXT }}/health/ready
+            {{- else }}
             path: /health/ready
+            {{- end }}
           failureThreshold: {{ .Values.apiServer.probes.readiness.failureThreshold }}
           initialDelaySeconds: {{ .Values.apiServer.probes.readiness.initialDelaySeconds }}
           periodSeconds: {{ .Values.apiServer.probes.readiness.periodSeconds }}


### PR DESCRIPTION
Added conditional logic to readiness and liveness probes:

If CONTEXT env variable is different from the default "/", then path will be updated to use CONTEXT var as prefix.

If not, then default probe paths are used.

**I'm new to this, so please validate:)**

Some context. Currently, on setting CONTEXT env variable to say /api. Both probes fail. This should fix that.