### PR TITLE
Fix persistent volume in deployment manifest

### DIFF
--- a/charts/dependency-track/templates/api-server/deployment.yaml
+++ b/charts/dependency-track/templates/api-server/deployment.yaml
@@ -114,7 +114,6 @@ spec:
       {{- toYaml .Values.apiServer.nodeSelector | nindent 8 }}
       {{- end }}
       volumes:
-      {{- if not .Values.apiServer.persistentVolume.enabled }}
       - name: data
         {{- if .Values.apiServer.persistentVolume.enabled }}
         persistentVolumeClaim:
@@ -122,7 +121,6 @@ spec:
         {{- else }}
         emptyDir: { }
         {{- end }}
-      {{- end }}
       - name: tmp
         emptyDir: { }
       {{- with (include "dependencytrack.secretKeySecretName" .) }}


### PR DESCRIPTION
Right now, `data` volume doesn't get defined in the deployment manifest regardless of the value of `.Values.apiServer.persistentVolume.enabled`. 

The PR fixes this volume config.