### PR TITLE
Lower default hyades API server memory request and limit to 2Gi

### DIFF
--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -41,10 +41,10 @@ apiServer:
   resources:
     requests:
       cpu: "2"
-      memory: 4Gi
+      memory: 2Gi
     limits:
       cpu: "4"
-      memory: 8Gi
+      memory: 2Gi
   extraEnv: []
   extraEnvFrom: []
   probes:


### PR DESCRIPTION
Due to various efficiency improvements we made in the recent past, API server instances no longer need as much memory. Also, increased memory requirements can now be addressed by spawning more replicas.

`requests.memory` and `limits.memory` are set to the same value, in order to lower the chances of pods getting `OOMKilled`. See https://xebia.com/blog/guide-kubernetes-jvm-integration/ for reference.