### PR TITLE
Allow image tags to be specified as `sha256` digest

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dependency-track
-version: 0.16.0
+version: 0.17.0
 type: application
 appVersion: 4.11.7
 description: |-

--- a/charts/dependency-track/templates/_helpers.tpl
+++ b/charts/dependency-track/templates/_helpers.tpl
@@ -53,7 +53,7 @@ API server labels
 {{- define "dependencytrack.apiServerLabels" -}}
 {{ include "dependencytrack.commonLabels" . }}
 {{ include "dependencytrack.apiServerSelectorLabels" . }}
-app.kubernetes.io/version: {{ (.Values.apiServer.image.tag | default .Chart.AppVersion) | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}
 
 {{/*
@@ -83,7 +83,11 @@ API server fully qualified name
 API server image
 */}}
 {{- define "dependencytrack.apiServerImage" -}}
+{{- if eq (substr 0 7 .Values.apiServer.image.tag) "sha256:" -}}
+{{- printf "%s/%s@%s" (.Values.apiServer.image.registry | default .Values.common.image.registry) .Values.apiServer.image.repository .Values.apiServer.image.tag -}}
+{{- else -}}
 {{- printf "%s/%s:%s" (.Values.apiServer.image.registry | default .Values.common.image.registry) .Values.apiServer.image.repository (.Values.apiServer.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
 {{- end -}}
 
 
@@ -93,7 +97,7 @@ Frontend labels
 {{- define "dependencytrack.frontendLabels" -}}
 {{ include "dependencytrack.commonLabels" . }}
 {{ include "dependencytrack.frontendSelectorLabels" . }}
-app.kubernetes.io/version: {{ (.Values.frontend.image.tag | default .Chart.AppVersion) | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}
 
 {{/*
@@ -123,7 +127,11 @@ Frontend fully qualified name
 Frontend image
 */}}
 {{- define "dependencytrack.frontendImage" -}}
+{{- if eq (substr 0 7 .Values.frontend.image.tag) "sha256:" -}}
+{{- printf "%s/%s@%s" (.Values.frontend.image.registry | default .Values.common.image.registry) .Values.frontend.image.repository .Values.frontend.image.tag -}}
+{{- else -}}
 {{- printf "%s/%s:%s" (.Values.frontend.image.registry | default .Values.common.image.registry) .Values.frontend.image.repository (.Values.frontend.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -27,7 +27,9 @@ apiServer:
     # -- Override common.image.registry for the API server.
     registry: ''
     repository: dependencytrack/apiserver
-    tag: ~
+    # -- Can be a tag name such as "latest", or an image digest
+    # prefixed with "sha256:". Defaults to AppVersion of the chart.
+    tag: ""
     pullPolicy: IfNotPresent
   command: []
   args: []
@@ -119,7 +121,9 @@ frontend:
     # -- Override common.image.registry for the frontend.
     registry: ''
     repository: dependencytrack/frontend
-    tag: ~
+    # -- Can be a tag name such as "latest", or an image digest
+    # prefixed with "sha256:". Defaults to AppVersion of the chart.
+    tag: ""
     pullPolicy: IfNotPresent
   command: []
   args: []

--- a/charts/hyades/Chart.yaml
+++ b/charts/hyades/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: hyades
-version: 0.5.0
+version: 0.6.0
 type: application
-appVersion: 1.0.0-SNAPSHOT
+appVersion: 0.6.0-SNAPSHOT
 description: |-
   Hyades is an incubating project for decoupling responsibilities from Dependency-Track's
   monolithic API server into separate, scalable services. It will eventually become

--- a/charts/hyades/templates/_helpers.tpl
+++ b/charts/hyades/templates/_helpers.tpl
@@ -53,7 +53,7 @@ API server labels
 {{- define "hyades.apiServerLabels" -}}
 {{ include "hyades.commonLabels" . }}
 {{ include "hyades.apiServerSelectorLabels" . }}
-app.kubernetes.io/version: {{ (.Values.apiServer.image.tag | default .Chart.AppVersion) | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}
 
 {{/*
@@ -83,7 +83,11 @@ API server fully qualified name
 API server image
 */}}
 {{- define "hyades.apiServerImage" -}}
+{{- if eq (substr 0 7 .Values.apiServer.image.tag) "sha256:" -}}
+{{- printf "%s/%s@%s" (.Values.apiServer.image.registry | default .Values.common.image.registry) .Values.apiServer.image.repository .Values.apiServer.image.tag -}}
+{{- else -}}
 {{- printf "%s/%s:%s" (.Values.apiServer.image.registry | default .Values.common.image.registry) .Values.apiServer.image.repository (.Values.apiServer.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
 {{- end -}}
 
 
@@ -93,7 +97,7 @@ Frontend labels
 {{- define "hyades.frontendLabels" -}}
 {{ include "hyades.commonLabels" . }}
 {{ include "hyades.frontendSelectorLabels" . }}
-app.kubernetes.io/version: {{ (.Values.frontend.image.tag | default .Chart.AppVersion) | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}
 
 {{/*
@@ -123,7 +127,11 @@ Frontend fully qualified name
 Frontend image
 */}}
 {{- define "hyades.frontendImage" -}}
+{{- if eq (substr 0 7 .Values.frontend.image.tag) "sha256:" -}}
+{{- printf "%s/%s@%s" (.Values.frontend.image.registry | default .Values.common.image.registry) .Values.frontend.image.repository .Values.frontend.image.tag -}}
+{{- else -}}
 {{- printf "%s/%s:%s" (.Values.frontend.image.registry | default .Values.common.image.registry) .Values.frontend.image.repository (.Values.frontend.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
 {{- end -}}
 
 
@@ -133,7 +141,7 @@ Mirror service labels
 {{- define "hyades.mirrorServiceLabels" -}}
 {{ include "hyades.commonLabels" . }}
 {{ include "hyades.mirrorServiceSelectorLabels" . }}
-app.kubernetes.io/version: {{ (.Values.mirrorService.image.tag | default .Chart.AppVersion) | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}
 
 {{/*
@@ -163,7 +171,11 @@ Mirror service fully qualified name
 Mirror service image
 */}}
 {{- define "hyades.mirrorServiceImage" -}}
+{{- if eq (substr 0 7 .Values.mirrorService.image.tag) "sha256:" -}}
+{{- printf "%s/%s@%s" (.Values.mirrorService.image.registry | default .Values.common.image.registry) .Values.mirrorService.image.repository .Values.mirrorService.image.tag -}}
+{{- else -}}
 {{- printf "%s/%s:%s" (.Values.mirrorService.image.registry | default .Values.common.image.registry) .Values.mirrorService.image.repository (.Values.mirrorService.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
 {{- end -}}
 
 
@@ -173,7 +185,7 @@ Notification publisher labels
 {{- define "hyades.notificationPublisherLabels" -}}
 {{ include "hyades.commonLabels" . }}
 {{ include "hyades.notificationPublisherSelectorLabels" . }}
-app.kubernetes.io/version: {{ (.Values.notificationPublisher.image.tag | default .Chart.AppVersion) | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}
 
 {{/*
@@ -203,7 +215,11 @@ Notification publisher fully qualified name
 Notification publisher image
 */}}
 {{- define "hyades.notificationPublisherImage" -}}
+{{- if eq (substr 0 7 .Values.notificationPublisher.image.tag) "sha256:" -}}
+{{- printf "%s/%s@%s" (.Values.notificationPublisher.image.registry | default .Values.common.image.registry) .Values.notificationPublisher.image.repository .Values.notificationPublisher.image.tag -}}
+{{- else -}}
 {{- printf "%s/%s:%s" (.Values.notificationPublisher.image.registry | default .Values.common.image.registry) .Values.notificationPublisher.image.repository (.Values.notificationPublisher.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
 {{- end -}}
 
 
@@ -213,7 +229,7 @@ Repository metadata analyzer labels
 {{- define "hyades.repoMetaAnalyzerLabels" -}}
 {{ include "hyades.commonLabels" . }}
 {{ include "hyades.repoMetaAnalyzerSelectorLabels" . }}
-app.kubernetes.io/version: {{ (.Values.repoMetaAnalyzer.image.tag | default .Chart.AppVersion) | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}
 
 {{/*
@@ -243,7 +259,11 @@ Repository metadata analyzer fully qualified name
 Repository metadata analyzer image
 */}}
 {{- define "hyades.repoMetaAnalyzerImage" -}}
+{{- if eq (substr 0 7 .Values.repoMetaAnalyzer.image.tag) "sha256:" -}}
+{{- printf "%s/%s@%s" (.Values.repoMetaAnalyzer.image.registry | default .Values.common.image.registry) .Values.repoMetaAnalyzer.image.repository .Values.repoMetaAnalyzer.image.tag -}}
+{{- else -}}
 {{- printf "%s/%s:%s" (.Values.repoMetaAnalyzer.image.registry | default .Values.common.image.registry) .Values.repoMetaAnalyzer.image.repository (.Values.repoMetaAnalyzer.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
 {{- end -}}
 
 
@@ -253,7 +273,7 @@ Vulnerability analyzer labels
 {{- define "hyades.vulnAnalyzerLabels" -}}
 {{ include "hyades.commonLabels" . }}
 {{ include "hyades.vulnAnalyzerSelectorLabels" . }}
-app.kubernetes.io/version: {{ (.Values.vulnAnalyzer.image.tag | default .Chart.AppVersion) | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end -}}
 
 {{/*
@@ -283,7 +303,11 @@ Vulnerability analyzer fully qualified name
 Vulnerability analyzer image
 */}}
 {{- define "hyades.vulnAnalyzerImage" -}}
+{{- if eq (substr 0 7 .Values.vulnAnalyzer.image.tag) "sha256:" -}}
+{{- printf "%s/%s@%s" (.Values.vulnAnalyzer.image.registry | default .Values.common.image.registry) .Values.vulnAnalyzer.image.repository .Values.vulnAnalyzer.image.tag -}}
+{{- else -}}
 {{- printf "%s/%s:%s" (.Values.vulnAnalyzer.image.registry | default .Values.common.image.registry) .Values.vulnAnalyzer.image.repository (.Values.vulnAnalyzer.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -34,6 +34,8 @@ apiServer:
     # -- Override common.image.registry for the API server.
     registry: ""
     repository: dependencytrack/hyades-apiserver
+    # -- Can be a tag name such as "latest", or an image digest
+    # prefixed with "sha256:".
     tag: snapshot
     pullPolicy: Always
   command: []
@@ -109,6 +111,8 @@ frontend:
     # -- Override common.image.registry for the API frontend.
     registry: ""
     repository: dependencytrack/hyades-frontend
+    # -- Can be a tag name such as "latest", or an image digest
+    # prefixed with "sha256:".
     tag: snapshot
     pullPolicy: Always
   command: []
@@ -157,6 +161,8 @@ mirrorService:
     # -- Override common.image.registry for the mirror service.
     registry: ""
     repository: dependencytrack/hyades-mirror-service
+    # -- Can be a tag name such as "latest", or an image digest
+    # prefixed with "sha256:".
     tag: snapshot-native
     pullPolicy: Always
   command: []
@@ -199,6 +205,8 @@ notificationPublisher:
     # -- Override common.image.registry for the notification publisher.
     registry: ""
     repository: dependencytrack/hyades-notification-publisher
+    # -- Can be a tag name such as "latest", or an image digest
+    # prefixed with "sha256:".
     tag: snapshot-native
     pullPolicy: Always
   command: []
@@ -241,6 +249,8 @@ repoMetaAnalyzer:
     # -- Override common.image.registry for the repository metadata analyzer.
     registry: ""
     repository: dependencytrack/hyades-repository-meta-analyzer
+    # -- Can be a tag name such as "latest", or an image digest
+    # prefixed with "sha256:".
     tag: snapshot-native
     pullPolicy: Always
   command: []
@@ -288,6 +298,8 @@ vulnAnalyzer:
     # -- Override common.image.registry for the vulnerability analyzer.
     registry: ""
     repository: dependencytrack/hyades-vulnerability-analyzer
+    # -- Can be a tag name such as "latest", or an image digest
+    # prefixed with "sha256:".
     tag: snapshot-native
     pullPolicy: Always
   command: []


### PR DESCRIPTION
Allows image tags to be specified as `sha256` digest.

To avoid any formatting or length constraint issues, always use the chart's `appVersion` to the `app.kubernetes.io/version` label.

Fixes #111