### PR TITLE
Add initializer job for hyades

### DIFF
--- a/charts/hyades/ci/test-initializer-values.yaml
+++ b/charts/hyades/ci/test-initializer-values.yaml
@@ -7,6 +7,8 @@ common:
     bootstrapServers: "redpanda.{{ .Release.Namespace }}.svc.cluster.local:9092"
   secretKey:
     createSecret: true
+  serviceAccount:
+    automount: true
 
 apiServer:
   resources:
@@ -16,6 +18,13 @@ apiServer:
     limits:
       cpu: "2"
       memory: 512Mi
+
+initializer:
+  enabled: true
+  # chart-testing executes `helm install` with `--wait` flag,
+  # causing post-install hooks to never run.
+  # See https://github.com/helm/chart-testing/issues/202.
+  noHelmHook: true
 
 mirrorService:
   resources: &hyadesResources

--- a/charts/hyades/ci/test-vulnanalyzer-statefulset-values.yaml
+++ b/charts/hyades/ci/test-vulnanalyzer-statefulset-values.yaml
@@ -11,39 +11,27 @@ common:
 apiServer:
   resources:
     requests:
-      cpu: 500m
+      cpu: 100m
       memory: 512Mi
     limits:
-      cpu: 500m
+      cpu: "2"
       memory: 512Mi
 
 mirrorService:
-  resources:
+  resources: &hyadesResources
     requests:
-      cpu: 500m
+      cpu: 100m
       memory: 256Mi
     limits:
       cpu: 500m
       memory: 256Mi
 
 repoMetaAnalyzer:
-  resources:
-    requests:
-      cpu: 500m
-      memory: 256Mi
-    limits:
-      cpu: 500m
-      memory: 256Mi
+  resources: *hyadesResources
 
 vulnAnalyzer:
   useStatefulSet: true
-  resources:
-    requests:
-      cpu: 500m
-      memory: 256Mi
-    limits:
-      cpu: 500m
-      memory: 256Mi
+  resources: *hyadesResources
   persistentVolume:
     enabled: true
   extraEnv:

--- a/charts/hyades/templates/_helpers.tpl
+++ b/charts/hyades/templates/_helpers.tpl
@@ -92,6 +92,92 @@ API server image
 
 
 {{/*
+Initializer labels
+*/}}
+{{- define "hyades.initializerLabels" -}}
+{{ include "hyades.commonLabels" . }}
+{{ include "hyades.initializerSelectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end -}}
+
+{{/*
+Initializer selector labels
+*/}}
+{{- define "hyades.initializerSelectorLabels" -}}
+{{ include "hyades.commonSelectorLabels" . }}
+app.kubernetes.io/name: {{ printf "%s-initializer" (include "hyades.name" .) }}
+app.kubernetes.io/component: initializer
+{{- end -}}
+
+{{/*
+Initializer name
+*/}}
+{{- define "hyades.initializerName" -}}
+{{- printf "%s-initializer" (include "hyades.name" .) -}}
+{{- end -}}
+
+{{/*
+Initializer fully qualified name
+*/}}
+{{- define "hyades.initializerFullname" -}}
+{{- printf "%s-initializer" (include "hyades.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Initializer image
+*/}}
+{{- define "hyades.initializerImage" -}}
+{{- if eq (substr 0 7 .Values.initializer.image.tag) "sha256:" -}}
+{{- printf "%s/%s@%s" (.Values.initializer.image.registry | default .Values.common.image.registry) .Values.initializer.image.repository .Values.initializer.image.tag -}}
+{{- else -}}
+{{- printf "%s/%s:%s" (.Values.initializer.image.registry | default .Values.common.image.registry) .Values.initializer.image.repository (.Values.initializer.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Initializer waiter name
+*/}}
+{{- define "hyades.initializerWaiterName" -}}
+{{- printf "%s-waiter" (include "hyades.initializerName" .) -}}
+{{- end -}}
+
+{{/*
+Initializer waiter fully qualified name
+*/}}
+{{- define "hyades.initializerWaiterFullname" -}}
+{{- printf "%s-waiter" (include "hyades.initializerFullname" .) -}}
+{{- end -}}
+
+{{/*
+Initializer waiter image
+*/}}
+{{- define "hyades.initializerWaiterImage" -}}
+{{- if eq (substr 0 7 .Values.initializer.waiter.image.tag) "sha256:" -}}
+{{- printf "%s/%s@%s" (.Values.initializer.waiter.image.registry | default .Values.common.image.registry) .Values.initializer.waiter.image.repository .Values.initializer.waiter.image.tag -}}
+{{- else -}}
+{{- printf "%s/%s:%s" (.Values.initializer.waiter.image.registry | default .Values.common.image.registry) .Values.initializer.waiter.image.repository (.Values.initializer.waiter.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Initializer waiter container
+*/}}
+{{- define "hyades.initializerWaiterContainer" -}}
+name: {{ include "hyades.initializerWaiterName" . }}
+image: {{ include "hyades.initializerWaiterImage" . }}
+imagePullPolicy: {{ .Values.initializer.waiter.image.pullPolicy }}
+args:
+- wait
+- --for
+- condition=complete
+- --timeout
+- "5m"
+- job/{{ include "hyades.initializerFullname" . }}
+{{- end -}}
+
+
+{{/*
 Frontend labels
 */}}
 {{- define "hyades.frontendLabels" -}}

--- a/charts/hyades/templates/api-server/deployment.yaml
+++ b/charts/hyades/templates/api-server/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}
       initContainers:
+      {{- if .Values.initializer.enabled }}
+      - {{ include "hyades.initializerWaiterContainer" . | nindent 8 }}
+      {{- end }}
       {{- with .Values.apiServer.initContainers }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
@@ -48,10 +51,6 @@ spec:
         - name: ALPINE_SECRET_KEY_PATH
           value: "/var/run/secrets/secret.key"
         {{- end }}
-        - name: ALPINE_DATABASE_MODE
-          value: "external"
-        - name: ALPINE_DATABASE_DRIVER
-          value: "org.postgresql.Driver"
         {{- with .Values.common.database.jdbcUrl }}
         - name: ALPINE_DATABASE_URL
           value: {{ tpl . $ | quote }}
@@ -63,6 +62,10 @@ spec:
         {{- with .Values.common.database.password }}
         - name: ALPINE_DATABASE_PASSWORD
           value: {{ . | quote }}
+        {{- end }}
+        {{- if .Values.initializer.enabled }}
+        - name: INIT_TASKS_ENABLED
+          value: "false"
         {{- end }}
         - name: KAFKA_BOOTSTRAP_SERVERS
           value: {{ tpl .Values.common.kafka.bootstrapServers $ | quote }}

--- a/charts/hyades/templates/initializer/job.yaml
+++ b/charts/hyades/templates/initializer/job.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.initializer.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "hyades.initializerFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "hyades.initializerLabels" . | nindent 4 }}
+  {{- if not .Values.initializer.noHelmHook }}
+  annotations:
+    "helm.sh/hook": "post-install, post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+  {{- end }}
+spec:
+  template:
+    metadata:
+      labels: {{- include "hyades.initializerSelectorLabels" . | nindent 8 }}
+      {{- with .Values.initializer.annotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "hyades.serviceAccountName" . }}
+      containers:
+      - name: {{ include "hyades.initializerName" . }}
+        image: {{ include "hyades.initializerImage" . }}
+        imagePullPolicy: {{ .Values.initializer.image.pullPolicy }}
+        securityContext: {{ toYaml .Values.initializer.securityContext | nindent 10 }}
+        {{- with .Values.initializer.command }}
+        command: {{ toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.initializer.args }}
+        args: {{ toYaml . | nindent 8 }}
+        {{- end }}
+        resources: {{- toYaml .Values.initializer.resources | nindent 10 }}
+        env:
+        # Clear the defaults for garbage collector and heap size that we set in the API server's Dockerfile.
+        # Let the JVM deal with configuring itself appropriately for the available resources.
+        - name: JAVA_OPTIONS
+          value: ""
+        - name: INIT_TASKS_ENABLED
+          value: "true"
+        - name: INIT_AND_EXIT
+          value: "true"
+        - name: ALPINE_DATABASE_POOL_ENABLED
+          value: "false"
+        {{- with .Values.common.database.jdbcUrl }}
+        - name: ALPINE_DATABASE_URL
+          value: {{ tpl . $ | quote }}
+        {{- end}}
+        {{- with .Values.common.database.username }}
+        - name: ALPINE_DATABASE_USERNAME
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.common.database.password }}
+        - name: ALPINE_DATABASE_PASSWORD
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.initializer.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.initializer.extraEnvFrom }}
+        envFrom: {{ toYaml . | nindent 8 }}
+        {{- end }}
+        volumeMounts:
+        - name: tmp
+          subPath: data
+          mountPath: /data
+        - name: tmp
+          subPath: tmp
+          mountPath: /tmp
+      {{- with .Values.initializer.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.initializer.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: tmp
+        emptyDir: {}
+{{- end }}

--- a/charts/hyades/templates/initializer/role.yaml
+++ b/charts/hyades/templates/initializer/role.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.initializer.enabled .Values.initializer.waiter.createRole }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "hyades.initializerWaiterFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "hyades.commonLabels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/charts/hyades/templates/initializer/rolebinding.yaml
+++ b/charts/hyades/templates/initializer/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.initializer.enabled .Values.initializer.waiter.createRole }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "hyades.initializerWaiterFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "hyades.commonLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "hyades.initializerWaiterFullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "hyades.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/hyades/templates/mirror-service/deployment.yaml
+++ b/charts/hyades/templates/mirror-service/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}
       initContainers:
+      {{- if .Values.initializer.enabled }}
+      - {{ include "hyades.initializerWaiterContainer" . | nindent 8 }}
+      {{- end }}
       {{- with .Values.mirrorService.initContainers }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/hyades/templates/notification-publisher/deployment.yaml
+++ b/charts/hyades/templates/notification-publisher/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}
       initContainers:
+      {{- if .Values.initializer.enabled }}
+      - {{ include "hyades.initializerWaiterContainer" . | nindent 8 }}
+      {{- end }}
       {{- with .Values.notificationPublisher.initContainers }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/hyades/templates/repo-meta-analyzer/deployment.yaml
+++ b/charts/hyades/templates/repo-meta-analyzer/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}
       initContainers:
+      {{- if .Values.initializer.enabled }}
+      - {{ include "hyades.initializerWaiterContainer" . | nindent 8 }}
+      {{- end }}
       {{- with .Values.repoMetaAnalyzer.initContainers }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/hyades/templates/vuln-analyzer/deployment.yaml
+++ b/charts/hyades/templates/vuln-analyzer/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}
       initContainers:
+      {{- if .Values.initializer.enabled }}
+      - {{ include "hyades.initializerWaiterContainer" . | nindent 8 }}
+      {{- end }}
       {{- with .Values.notificationPublisher.initContainers }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/hyades/templates/vuln-analyzer/statefulset.yaml
+++ b/charts/hyades/templates/vuln-analyzer/statefulset.yaml
@@ -25,6 +25,9 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}
       initContainers:
+      {{- if .Values.initializer.enabled }}
+      - {{ include "hyades.initializerWaiterContainer" . | nindent 8 }}
+      {{- end }}
       {{- with .Values.notificationPublisher.initContainers }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}

--- a/charts/hyades/values.schema.json
+++ b/charts/hyades/values.schema.json
@@ -111,6 +111,9 @@
         "resources": {
           "$ref": "#/$defs/resources"
         },
+        "securityContext": {
+          "type": "object"
+        },
         "extraEnv": {
           "$ref": "#/$defs/objectArray"
         },
@@ -146,6 +149,61 @@
         }
       }
     },
+    "initializer": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "image": {
+          "$ref": "#/$defs/image"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "resources": {
+          "$ref": "#/$defs/resources"
+        },
+        "securityContext": {
+          "type": "object"
+        },
+        "extraEnv": {
+          "$ref": "#/$defs/objectArray"
+        },
+        "extraEnvFrom": {
+          "$ref": "#/$defs/objectArray"
+        },
+        "tolerations": {
+          "$ref": "#/$defs/objectArray"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "waiter": {
+          "type": "object",
+          "properties": {
+            "image": {
+              "$ref": "#/$defs/image"
+            },
+            "createRole": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "frontend": {
       "type": "object",
       "properties": {
@@ -175,6 +233,9 @@
         },
         "resources": {
           "$ref": "#/$defs/resources"
+        },
+        "securityContext": {
+          "type": "object"
         },
         "extraEnv": {
           "$ref": "#/$defs/objectArray"
@@ -243,6 +304,9 @@
         "resources": {
           "$ref": "#/$defs/resources"
         },
+        "securityContext": {
+          "type": "object"
+        },
         "extraEnv": {
           "$ref": "#/$defs/objectArray"
         },
@@ -302,6 +366,9 @@
         "resources": {
           "$ref": "#/$defs/resources"
         },
+        "securityContext": {
+          "type": "object"
+        },
         "extraEnv": {
           "$ref": "#/$defs/objectArray"
         },
@@ -360,6 +427,9 @@
         },
         "resources": {
           "$ref": "#/$defs/resources"
+        },
+        "securityContext": {
+          "type": "object"
         },
         "extraEnv": {
           "$ref": "#/$defs/objectArray"
@@ -422,6 +492,9 @@
         },
         "resources": {
           "$ref": "#/$defs/resources"
+        },
+        "securityContext": {
+          "type": "object"
         },
         "persistentVolume":{
           "type": "object",

--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -30,7 +30,7 @@ apiServer:
   enabled: true
   replicaCount: 1
   annotations: {}
-  image:
+  image: &apiServerImage
     # -- Override common.image.registry for the API server.
     registry: ""
     repository: dependencytrack/hyades-apiserver
@@ -113,6 +113,45 @@ apiServer:
   additionalVolumeMounts: []
   tolerations: []
   nodeSelector: {}
+
+initializer:
+  # -- Whether to enable the initializer Job.
+  # When enabled, an init container will be added to all
+  # deployments that require database access.
+  # The init container will wait for the initializer Job to complete.
+  # Requires the service account token to be mounted.
+  enabled: false
+  # -- Whether to NOT deploy the initializer Job as `post-install` and `post-upgrade`
+  # Helm hook. Deploying as Helm hook can create deadlock situations when `helm install`
+  # and `helm upgrade` are executed with `--wait` flag. See <https://github.com/helm/helm/issues/10555>.
+  # Note that without hooks, `helm upgrade` may fail due to Job fields being immutable.
+  noHelmHook: false
+  annotations: {}
+  image: *apiServerImage
+  command: []
+  args: []
+  resources:
+    requests:
+      cpu: 150m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  # -- Security context of the Container.
+  securityContext: *hyadesSecurityContext
+  extraEnv: []
+  extraEnvFrom: []
+  tolerations: []
+  nodeSelector: {}
+  waiter:
+    image:
+      registry: "docker.io"
+      repository: bitnami/kubectl
+      tag: latest
+      pullPolicy: Always
+    # -- Whether to create a Role with permissions to
+    # wait for Job completion, and bind it to the ServiceAccount.
+    createRole: true
 
 frontend:
   # -- Whether the frontend shall be deployed.


### PR DESCRIPTION
Introduces a `Job` that executes in the `post-install` and `post-upgrade` phases of a Helm deployment. The job executes initialization tasks and exits.

Pods that depend on successful execution of the job will wait for it, using new init containers. Since this waiting requires interacting with the Kubernetes API, pods will need `get`, `list`, and `watch` permissions on the `batch/jobs` resource. Creation of a `Role` with those permissions can be enabled.

This new functionality is disabled by default for now. The plan is to enable it per default once it's thoroughly tested, and we are confident it's the best way forward.

Depends on https://github.com/DependencyTrack/hyades-apiserver/pull/873

Closes #136