### PR TITLE
Add /health endpoint support when using ingress

### DIFF
--- a/charts/dependency-track/templates/ingress.yaml
+++ b/charts/dependency-track/templates/ingress.yaml
@@ -32,6 +32,13 @@ spec:
             name: {{ include "dependencytrack.apiServerFullname" . }}
             port:
               name: web
+      - path: /health
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "dependencytrack.apiServerFullname" . }}
+            port:
+              name: web
       - path: /
         pathType: Prefix
         backend:


### PR DESCRIPTION
### Description / issue

- Add support for the /health endpoint introduced in version 4.8.0+ (https://docs.dependencytrack.org/getting-started/monitoring/)
- Because of the current ingress configuration the */health* endpoint will direct traffic to the frontend which will return a *404 Not found* whereas the api-server should handle the route

### How to test

- Apply helm chart with ingress enabled

Note: I already tested on an dependency track deployment running on openshift (chart version 0.15.0) by simply adding:

(note that dtrack-dev is the deployment name I used)

```
- path: /health
  pathType: Prefix
  backend:
    service:
      name: dtrack-dev-dependency-track-api-server
      port:
        name: web
```

On GET \health I know properly get:
{"status":"UP","checks":[{"name":"database","status":"UP","data":{"nontx_connection_pool":"UP","tx_connection_pool":"UP"}}]}


