### PR TITLE
fix(frontend-service-port): corrected the port according to the official documentation

### DIFF
--- a/charts/hyades/templates/frontend/service.yaml
+++ b/charts/hyades/templates/frontend/service.yaml
@@ -13,7 +13,7 @@ spec:
   type: {{ .Values.frontend.service.type | quote }}
   ports:
   - name: web
-    port: 8080
+    port: 8081
     targetPort: web
     {{- with .Values.frontend.service.nodePort }}
     nodePort: {{ . }}


### PR DESCRIPTION
According to the official documentation here: https://github.com/DependencyTrack/hyades?tab=readme-ov-file#great-can-i-try-it-

The frontend service port exposed should be 8081. Here is que quote:

```
This will launch all required services, and expose the following endpoints:

| Service            | URL                    |
|:-------------------|:-----------------------|
| API Server         | http://localhost:8080  |
| Frontend           | http://localhost:8081  |
| Redpanda Console   | http://localhost:28080 |
| PostgreSQL         | `localhost:5432`       |
| Redpanda Kafka API | `localhost:9092`       |
```