### PR TITLE
Make deployment strategy of hyades services configurable

### DIFF
--- a/charts/hyades/templates/api-server/deployment.yaml
+++ b/charts/hyades/templates/api-server/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels: {{- include "hyades.apiServerLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.apiServer.replicaCount }}
+  strategy: {{- toYaml .Values.apiServer.deployment.strategy | nindent 4 }}
   selector:
     matchLabels: {{- include "hyades.apiServerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/frontend/deployment.yaml
+++ b/charts/hyades/templates/frontend/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels: {{- include "hyades.frontendLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.frontend.replicaCount }}
+  strategy: {{- toYaml .Values.frontend.deployment.strategy | nindent 4 }}
   selector:
     matchLabels: {{- include "hyades.frontendSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/mirror-service/deployment.yaml
+++ b/charts/hyades/templates/mirror-service/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels: {{- include "hyades.mirrorServiceLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.mirrorService.replicaCount }}
+  strategy: {{- toYaml .Values.mirrorService.deployment.strategy | nindent 4 }}
   selector:
     matchLabels: {{- include "hyades.mirrorServiceSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/notification-publisher/deployment.yaml
+++ b/charts/hyades/templates/notification-publisher/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels: {{- include "hyades.notificationPublisherLabels" .  | nindent 4 }}
 spec:
   replicas: {{ .Values.notificationPublisher.replicaCount }}
+  strategy: {{- toYaml .Values.notificationPublisher.deployment.strategy | nindent 4 }}
   selector:
     matchLabels: {{- include "hyades.notificationPublisherSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/repo-meta-analyzer/deployment.yaml
+++ b/charts/hyades/templates/repo-meta-analyzer/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels: {{- include "hyades.repoMetaAnalyzerLabels" .  | nindent 4 }}
 spec:
   replicas: {{ .Values.repoMetaAnalyzer.replicaCount }}
+  strategy: {{- toYaml .Values.repoMetaAnalyzer.deployment.strategy | nindent 4 }}
   selector:
     matchLabels: {{- include "hyades.repoMetaAnalyzerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/vuln-analyzer/deployment.yaml
+++ b/charts/hyades/templates/vuln-analyzer/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels: {{- include "hyades.vulnAnalyzerLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.vulnAnalyzer.replicaCount }}
+  strategy: {{- toYaml .Values.vulnAnalyzer.deployment.strategy | nindent 4 }}
   selector:
     matchLabels: {{- include "hyades.vulnAnalyzerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/values.schema.json
+++ b/charts/hyades/values.schema.json
@@ -90,6 +90,14 @@
         "replicaCount": {
           "type": "integer"
         },
+        "deployment": {
+          "type": "object",
+          "properties": {
+            "strategy": {
+              "type": "object"
+            }
+          }
+        },
         "annotations": {
           "type": "object"
         },
@@ -213,6 +221,14 @@
         "replicaCount": {
           "type": "number"
         },
+        "deployment": {
+          "type": "object",
+          "properties": {
+            "strategy": {
+              "type": "object"
+            }
+          }
+        },
         "annotations": {
           "type": "object"
         },
@@ -283,6 +299,14 @@
           "minimum": 0,
           "maximum": 1
         },
+        "deployment": {
+          "type": "object",
+          "properties": {
+            "strategy": {
+              "type": "object"
+            }
+          }
+        },
         "annotations": {
           "type": "object"
         },
@@ -345,6 +369,14 @@
         "replicaCount": {
           "type": "integer"
         },
+        "deployment": {
+          "type": "object",
+          "properties": {
+            "strategy": {
+              "type": "object"
+            }
+          }
+        },
         "annotations": {
           "type": "object"
         },
@@ -406,6 +438,14 @@
         },
         "replicaCount": {
           "type": "integer"
+        },
+        "deployment": {
+          "type": "object",
+          "properties": {
+            "strategy": {
+              "type": "object"
+            }
+          }
         },
         "annotations": {
           "type": "object"
@@ -471,6 +511,14 @@
         },
         "replicaCount": {
           "type": "integer"
+        },
+        "deployment": {
+          "type": "object",
+          "properties": {
+            "strategy": {
+              "type": "object"
+            }
+          }
         },
         "annotations": {
           "type": "object"

--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -29,6 +29,10 @@ apiServer:
   # -- Whether the API server shall be deployed.
   enabled: true
   replicaCount: 1
+  deployment:
+    # -- The deployment strategy to use.
+    strategy:
+      type: RollingUpdate
   annotations: {}
   image: &apiServerImage
     # -- Override common.image.registry for the API server.
@@ -158,6 +162,10 @@ frontend:
   # -- Whether the frontend shall be deployed.
   enabled: true
   replicaCount: 1
+  deployment:
+    # -- The deployment strategy to use.
+    strategy:
+      type: RollingUpdate
   annotations: {}
   image:
     # -- Override common.image.registry for the API frontend.
@@ -222,6 +230,12 @@ mirrorService:
   enabled: true
   # -- Number of replicas. Should be <= 1.
   replicaCount: 1
+  deployment:
+    # -- The deployment strategy to use. `Recreate` is recommended because the service
+    # does not serve user-traffic, and `RollingUpdate` will cause undesired
+    # Kafka consumer rebalances.
+    strategy:
+      type: Recreate
   annotations: {}
   image:
     # -- Override common.image.registry for the mirror service.
@@ -270,6 +284,12 @@ notificationPublisher:
   # -- Whether the notification publisher shall be deployed.
   enabled: true
   replicaCount: 1
+  deployment:
+    # -- The deployment strategy to use. `Recreate` is recommended because the service
+    # does not serve user-traffic, and `RollingUpdate` will cause undesired
+    # Kafka consumer rebalances.
+    strategy:
+      type: Recreate
   annotations: {}
   image:
     # -- Override common.image.registry for the notification publisher.
@@ -319,6 +339,12 @@ repoMetaAnalyzer:
   enabled: true
   annotations: {}
   replicaCount: 1
+  deployment:
+    # -- The deployment strategy to use. `Recreate` is recommended because the service
+    # does not serve user-traffic, and `RollingUpdate` will cause undesired
+    # Kafka consumer rebalances.
+    strategy:
+      type: Recreate
   image:
     # -- Override common.image.registry for the repository metadata analyzer.
     registry: ""
@@ -372,6 +398,12 @@ vulnAnalyzer:
   useStatefulSet: false
   annotations: {}
   replicaCount: 1
+  deployment:
+    # -- The deployment strategy to use. `Recreate` is recommended because the service
+    # does not serve user-traffic, and `RollingUpdate` will cause undesired
+    # Kafka consumer rebalances.
+    strategy:
+      type: Recreate
   image:
     # -- Override common.image.registry for the vulnerability analyzer.
     registry: ""


### PR DESCRIPTION
For Kafka consumers, it can be desirable to *not* do `RollingUpdate`s in order to prevent repetetive rebalances. Since those services are not user-facing anyway, there's no downtime involved in following a `Recreate` strategy instead.