### PR TITLE
Support extraPodLabels in apiServer and Frontend

### DIFF
--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -30,6 +30,7 @@ that allows organizations to identify and reduce risk in the software supply cha
 | apiServer.extraContainers | list | `[]` | Additional containers to deploy. Supports templating. |
 | apiServer.extraEnv | list | `[]` |  |
 | apiServer.extraEnvFrom | list | `[]` |  |
+| apiServer.extraPodLabels | object | `{}` | |
 | apiServer.image.pullPolicy | string | `"IfNotPresent"` |  |
 | apiServer.image.registry | string | `""` | Override common.image.registry for the API server. |
 | apiServer.image.repository | string | `"dependencytrack/apiserver"` |  |
@@ -83,6 +84,7 @@ that allows organizations to identify and reduce risk in the software supply cha
 | frontend.extraContainers | list | `[]` | Additional containers to deploy. Supports templating. |
 | frontend.extraEnv | list | `[]` |  |
 | frontend.extraEnvFrom | list | `[]` |  |
+| frontend.extraPodLabels | object | `{}` | |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | frontend.image.registry | string | `""` | Override common.image.registry for the frontend. |
 | frontend.image.repository | string | `"dependencytrack/frontend"` |  |

--- a/charts/dependency-track/templates/api-server/deployment.yaml
+++ b/charts/dependency-track/templates/api-server/deployment.yaml
@@ -13,6 +13,9 @@ spec:
   template:
     metadata:
       labels: {{ include "dependencytrack.apiServerSelectorLabels" . | nindent 8 }}
+      {{- if .Values.apiServer.extraPodLabels }}
+      {{- toYaml .Values.apiServer.extraPodLabels | nindent 8 }}
+      {{- end }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: /metrics

--- a/charts/dependency-track/templates/api-server/statefulset.yaml
+++ b/charts/dependency-track/templates/api-server/statefulset.yaml
@@ -14,6 +14,9 @@ spec:
   template:
     metadata:
       labels: {{ include "dependencytrack.apiServerSelectorLabels" . | nindent 8 }}
+      {{- if .Values.apiServer.extraPodLabels }}
+      {{- toYaml .Values.apiServer.extraPodLabels | nindent 8 }}
+      {{- end }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: /metrics

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   template:
     metadata:
       labels: {{- include "dependencytrack.frontendSelectorLabels" . | nindent 8 }}
+      {{- if .Values.frontend.extraPodLabels }}
+      {{- toYaml .Values.frontend.extraPodLabels | nindent 8 }}
+      {{- end }}
       {{- with .Values.frontend.annotations }}
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/dependency-track/values.schema.json
+++ b/charts/dependency-track/values.schema.json
@@ -109,6 +109,9 @@
         "extraContainers": {
           "$ref": "#/$defs/objectArray"
         },
+        "extraPodLabels": {
+          "type": "object"
+        },
         "tolerations": {
           "$ref": "#/$defs/objectArray"
         },
@@ -173,6 +176,9 @@
         },
         "extraContainers": {
           "$ref": "#/$defs/objectArray"
+        },
+        "extraPodLabels": {
+          "type": "object"
         },
         "tolerations": {
           "$ref": "#/$defs/objectArray"

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -70,6 +70,7 @@ apiServer:
   extraEnvFrom: []
   # -- Additional containers to deploy. Supports templating.
   extraContainers: []
+  extraPodLabels: {}
   tolerations: []
   probes:
     liveness:
@@ -161,6 +162,7 @@ frontend:
   extraEnvFrom: []
   # -- Additional containers to deploy. Supports templating.
   extraContainers: []
+  extraPodLabels: {}
   tolerations: []
   probes:
     liveness:


### PR DESCRIPTION
#32

Creates `extraPodLabels` so that a user can set specific pod labels in either the `apiServer` or `frontend` deployment.