### PR TITLE
Fix .Values.apiServer.serviceMonitor.scrapeTimeout

### DIFF
--- a/charts/dependency-track/templates/api-server/servicemonitor.yaml
+++ b/charts/dependency-track/templates/api-server/servicemonitor.yaml
@@ -17,5 +17,5 @@ spec:
   - port: web
     path: /metrics
     interval: {{ .Values.apiServer.serviceMonitor.scrapeInternal }}
-    timeout: {{ .Values.apiServer.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.apiServer.serviceMonitor.scrapeTimeout }}
 {{- end }}


### PR DESCRIPTION
Fixes #170

As per [this](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint) documentation, the API endpoint `timeout` does not exist and should be `scrapeTimeout`.