### PR TITLE
Fix default values and naming for scrape interval

### DIFF
--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -61,7 +61,7 @@ that allows organizations to identify and reduce risk in the software supply cha
 | apiServer.service.type | string | `"ClusterIP"` |  |
 | apiServer.serviceMonitor.enabled | bool | `false` |  |
 | apiServer.serviceMonitor.namespace | string | `"monitoring"` |  |
-| apiServer.serviceMonitor.scrapeInternal | string | `"15s"` |  |
+| apiServer.serviceMonitor.scrapeInterval | string | `"60s"` |  |
 | apiServer.serviceMonitor.scrapeTimeout | string | `"30s"` |  |
 | apiServer.tolerations | list | `[]` |  |
 | common.fullnameOverride | string | `""` |  |
@@ -116,4 +116,3 @@ that allows organizations to identify and reduce risk in the software supply cha
 | ingress.hostname | string | `"example.com"` |  |
 | ingress.ingressClassName | string | `""` |  |
 | ingress.tls | list | `[]` |  |
-

--- a/charts/dependency-track/templates/api-server/servicemonitor.yaml
+++ b/charts/dependency-track/templates/api-server/servicemonitor.yaml
@@ -16,6 +16,6 @@ spec:
   endpoints:
   - port: web
     path: /metrics
-    interval: {{ .Values.apiServer.serviceMonitor.scrapeInternal }}
+    interval: {{ .Values.apiServer.serviceMonitor.scrapeInterval }}
     scrapeTimeout: {{ .Values.apiServer.serviceMonitor.scrapeTimeout }}
 {{- end }}

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -99,7 +99,7 @@ apiServer:
   serviceMonitor:
     enabled: false
     namespace: monitoring
-    scrapeInternal: 15s
+    scrapeInterval: 60s
     scrapeTimeout: 30s
   # -- Additional init containers to deploy. Supports templating.
   initContainers: []


### PR DESCRIPTION
- Fixed the wording for interval (`scrapeInternal` -> `scrapeInterval`).
- Increased the default value for `scrapeInterval` now that `scrapeTimeout` is fixed (https://github.com/DependencyTrack/helm-charts/pull/171) because it makes the service monitor invalid (`ServiceMonitor dependencytrack-api-server was rejected due to invalid configuration: scrapeTimeout "30s" greater than scrapeInterval "15s"`).