### PR TITLE
Update helm chart to remove replicas and update strategy for HPA

### DIFF
--- a/charts/hyades/templates/api-server/deployment.yaml
+++ b/charts/hyades/templates/api-server/deployment.yaml
@@ -7,8 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.apiServerLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.apiServer.replicaCount }}
-  strategy: {{- toYaml .Values.apiServer.deployment.strategy | nindent 4 }}
+  {{- if .Values.apiServer.replicas.enabled }}
+  replicas: {{ .Values.apiServer.replicas.replicaCount }}
+  {{- end }}
+  {{- if .Values.apiServer.deployment.strategy.enabled }}
+  strategy:
+    type: {{ .Values.apiServer.deployment.strategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.apiServerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/frontend/deployment.yaml
+++ b/charts/hyades/templates/frontend/deployment.yaml
@@ -7,8 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.frontendLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.frontend.replicaCount }}
-  strategy: {{- toYaml .Values.frontend.deployment.strategy | nindent 4 }}
+  {{- if .Values.frontend.replicas.enabled }}
+  replicas: {{ .Values.frontend.replicas.replicaCount }}
+  {{- end }}
+  {{- if .Values.frontend.deployment.strategy.enabled }}
+  strategy:
+    type: {{ .Values.frontend.deployment.strategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.frontendSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/mirror-service/deployment.yaml
+++ b/charts/hyades/templates/mirror-service/deployment.yaml
@@ -7,8 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.mirrorServiceLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.mirrorService.replicaCount }}
-  strategy: {{- toYaml .Values.mirrorService.deployment.strategy | nindent 4 }}
+  {{- if .Values.mirrorService.replicas.enabled }}
+  replicas: {{ .Values.mirrorService.replicas.replicaCount }}
+  {{- end }}
+  {{- if .Values.mirrorService.deployment.strategy.enabled }}
+  strategy:
+    type: {{ .Values.mirrorService.deployment.strategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.mirrorServiceSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/notification-publisher/deployment.yaml
+++ b/charts/hyades/templates/notification-publisher/deployment.yaml
@@ -7,8 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.notificationPublisherLabels" .  | nindent 4 }}
 spec:
-  replicas: {{ .Values.notificationPublisher.replicaCount }}
-  strategy: {{- toYaml .Values.notificationPublisher.deployment.strategy | nindent 4 }}
+  {{- if .Values.notificationPublisher.replicas.enabled }}
+  replicas: {{ .Values.notificationPublisher.replicas.replicaCount }}
+  {{- end }}
+  {{- if .Values.notificationPublisher.deployment.strategy.enabled }}
+  strategy:
+    type: {{ .Values.notificationPublisher.deployment.strategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.notificationPublisherSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/repo-meta-analyzer/deployment.yaml
+++ b/charts/hyades/templates/repo-meta-analyzer/deployment.yaml
@@ -7,8 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.repoMetaAnalyzerLabels" .  | nindent 4 }}
 spec:
-  replicas: {{ .Values.repoMetaAnalyzer.replicaCount }}
-  strategy: {{- toYaml .Values.repoMetaAnalyzer.deployment.strategy | nindent 4 }}
+  {{- if .Values.repoMetaAnalyzer.replicas.enabled }}
+  replicas: {{ .Values.repoMetaAnalyzer.replicas.replicaCount }}
+  {{- end }}
+  {{- if .Values.repoMetaAnalyzer.deployment.strategy.enabled }}
+  strategy:
+    type: {{ .Values.repoMetaAnalyzer.deployment.strategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.repoMetaAnalyzerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/vuln-analyzer/deployment.yaml
+++ b/charts/hyades/templates/vuln-analyzer/deployment.yaml
@@ -7,8 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.vulnAnalyzerLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.vulnAnalyzer.replicaCount }}
-  strategy: {{- toYaml .Values.vulnAnalyzer.deployment.strategy | nindent 4 }}
+  {{- if .Values.vulnAnalyzer.replicas.enabled }}
+  replicas: {{ .Values.vulnAnalyzer.replicas.replicaCount }}
+  {{- end }}
+  {{- if .Values.vulnAnalyzer.deployment.strategy.enabled }}
+  strategy:
+    type: {{ .Values.vulnAnalyzer.deployment.strategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.vulnAnalyzerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -28,10 +28,13 @@ common:
 apiServer:
   # -- Whether the API server shall be deployed.
   enabled: true
-  replicaCount: 1
+  replicas:
+    enabled: true
+    replicaCount: 1
   deployment:
     # -- The deployment strategy to use.
     strategy:
+      enabled: true
       type: RollingUpdate
   annotations: {}
   image: &apiServerImage
@@ -161,10 +164,13 @@ initializer:
 frontend:
   # -- Whether the frontend shall be deployed.
   enabled: true
-  replicaCount: 1
+  replicas:
+    enabled: true
+    replicaCount: 1
   deployment:
     # -- The deployment strategy to use.
     strategy:
+      enabled: true
       type: RollingUpdate
   annotations: {}
   image:
@@ -229,12 +235,15 @@ mirrorService:
   # -- Whether the mirror service shall be deployed.
   enabled: true
   # -- Number of replicas. Should be <= 1.
-  replicaCount: 1
+  replicas:
+    enabled: true
+    replicaCount: 1
   deployment:
     # -- The deployment strategy to use. `Recreate` is recommended because the service
     # does not serve user-traffic, and `RollingUpdate` will cause undesired
     # Kafka consumer rebalances.
     strategy:
+      enabled: true
       type: Recreate
   annotations: {}
   image:
@@ -283,12 +292,15 @@ mirrorService:
 notificationPublisher:
   # -- Whether the notification publisher shall be deployed.
   enabled: true
-  replicaCount: 1
+  replicas:
+    enabled: true
+    replicaCount: 1
   deployment:
     # -- The deployment strategy to use. `Recreate` is recommended because the service
     # does not serve user-traffic, and `RollingUpdate` will cause undesired
     # Kafka consumer rebalances.
     strategy:
+      enabled: true
       type: Recreate
   annotations: {}
   image:
@@ -338,12 +350,15 @@ repoMetaAnalyzer:
   # -- Whether the repository metadata analyzer shall be deployed.
   enabled: true
   annotations: {}
-  replicaCount: 1
+  replicas:
+    enabled: true
+    replicaCount: 1
   deployment:
     # -- The deployment strategy to use. `Recreate` is recommended because the service
     # does not serve user-traffic, and `RollingUpdate` will cause undesired
     # Kafka consumer rebalances.
     strategy:
+      enabled: true
       type: Recreate
   image:
     # -- Override common.image.registry for the repository metadata analyzer.
@@ -397,12 +412,15 @@ vulnAnalyzer:
   # state to disk. Should be used in combination with persistentVolume.enabled.
   useStatefulSet: false
   annotations: {}
-  replicaCount: 1
+  replicas:
+    enabled: true
+    replicaCount: 1
   deployment:
     # -- The deployment strategy to use. `Recreate` is recommended because the service
     # does not serve user-traffic, and `RollingUpdate` will cause undesired
     # Kafka consumer rebalances.
     strategy:
+      enabled: true
       type: Recreate
   image:
     # -- Override common.image.registry for the vulnerability analyzer.


### PR DESCRIPTION
Enable turning on/off the `replica` and `strategy.update` fields so HPA can be used with all the deployments