### PR TITLE
Update to allow HPA configuration

### DIFF
--- a/charts/hyades/templates/api-server/deployment.yaml
+++ b/charts/hyades/templates/api-server/deployment.yaml
@@ -7,13 +7,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.apiServerLabels" . | nindent 4 }}
 spec:
-  {{- if .Values.apiServer.replicas.enabled }}
-  replicas: {{ .Values.apiServer.replicas.replicaCount }}
+  {{- if (not .Values.apiServer.autoScaling.enabled) }}
+  replicas: {{ .Values.apiServer.replicaCount }}
   {{- end }}
-  {{- if .Values.apiServer.deployment.strategy.enabled }}
   strategy:
     type: {{ .Values.apiServer.deployment.strategy.type }}
-  {{- end }}
   selector:
     matchLabels: {{- include "hyades.apiServerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/api-server/deployment.yaml
+++ b/charts/hyades/templates/api-server/deployment.yaml
@@ -7,8 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.apiServerLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.apiServer.replicaCount }}
-  strategy: {{- toYaml .Values.apiServer.deployment.strategy | nindent 4 }}
+  {{- if .Values.apiServer.replicas.enabled }}
+  replicas: {{ .Values.apiServer.replicas.replicaCount }}
+  {{- end }}
+  {{- if .Values.apiServer.deployment.strategy.enabled }}
+  strategy:
+    type: {{ .Values.apiServer.deployment.strategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.apiServerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/api-server/hpa.yaml
+++ b/charts/hyades/templates/api-server/hpa.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.apiServer.autoScaling.enabled .Values.apiServer.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "hyades.apiServerFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "hyades.apiServerLabels" . | nindent 4 }}
+  {{- if .Values.apiServer.autoScaling.annotations }}
+  annotations:
+  {{- with .Values.apiServer.autoScaling.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "hyades.apiServerFullname" . }}
+  minReplicas: {{ .Values.apiServer.autoScaling.minReplicas }}
+  maxReplicas: {{ .Values.apiServer.autoScaling.maxReplicas }}
+  metrics:
+    {{- if .Values.apiServer.autoScaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.apiServer.autoScaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.apiServer.autoScaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.apiServer.autoScaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/hyades/templates/frontend/deployment.yaml
+++ b/charts/hyades/templates/frontend/deployment.yaml
@@ -7,8 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.frontendLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.frontend.replicaCount }}
-  strategy: {{- toYaml .Values.frontend.deployment.strategy | nindent 4 }}
+  {{- if .Values.frontend.replicas.enabled }}
+  replicas: {{ .Values.frontend.replicas.replicaCount }}
+  {{- end }}
+  {{- if .Values.frontend.deployment.strategy.enabled }}
+  strategy:
+    type: {{ .Values.frontend.deployment.strategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.frontendSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/frontend/deployment.yaml
+++ b/charts/hyades/templates/frontend/deployment.yaml
@@ -7,13 +7,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.frontendLabels" . | nindent 4 }}
 spec:
-  {{- if .Values.frontend.replicas.enabled }}
-  replicas: {{ .Values.frontend.replicas.replicaCount }}
+  {{- if (not .Values.frontend.autoScaling.enabled) }}
+  replicas: {{ .Values.frontend.replicaCount }}
   {{- end }}
-  {{- if .Values.frontend.deployment.strategy.enabled }}
   strategy:
     type: {{ .Values.frontend.deployment.strategy.type }}
-  {{- end }}
   selector:
     matchLabels: {{- include "hyades.frontendSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/frontend/hpa.yaml
+++ b/charts/hyades/templates/frontend/hpa.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.frontend.autoScaling.enabled .Values.frontend.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "hyades.frontendFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "hyades.frontendLabels" . | nindent 4 }}
+  {{- if .Values.frontend.autoScaling.annotations }}
+  annotations:
+  {{- with .Values.frontend.autoScaling.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "hyades.frontendFullname" . }}
+  minReplicas: {{ .Values.frontend.autoScaling.minReplicas }}
+  maxReplicas: {{ .Values.frontend.autoScaling.maxReplicas }}
+  metrics:
+    {{- if .Values.frontend.autoScaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.frontend.autoScaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.frontend.autoScaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.frontend.autoScaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/hyades/templates/mirror-service/deployment.yaml
+++ b/charts/hyades/templates/mirror-service/deployment.yaml
@@ -7,13 +7,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.mirrorServiceLabels" . | nindent 4 }}
 spec:
-  {{- if .Values.mirrorService.replicas.enabled }}
-  replicas: {{ .Values.mirrorService.replicas.replicaCount }}
-  {{- end }}
-  {{- if .Values.mirrorService.deployment.strategy.enabled }}
-  strategy:
-    type: {{ .Values.mirrorService.deployment.strategy.type }}
-  {{- end }}
+  replicas: {{ .Values.mirrorService.replicaCount }}
+  strategy: {{- toYaml .Values.mirrorService.deployment.strategy | nindent 4 }}
   selector:
     matchLabels: {{- include "hyades.mirrorServiceSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/mirror-service/deployment.yaml
+++ b/charts/hyades/templates/mirror-service/deployment.yaml
@@ -7,8 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.mirrorServiceLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.mirrorService.replicaCount }}
-  strategy: {{- toYaml .Values.mirrorService.deployment.strategy | nindent 4 }}
+  {{- if .Values.mirrorService.replicas.enabled }}
+  replicas: {{ .Values.mirrorService.replicas.replicaCount }}
+  {{- end }}
+  {{- if .Values.mirrorService.deployment.strategy.enabled }}
+  strategy:
+    type: {{ .Values.mirrorService.deployment.strategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.mirrorServiceSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/notification-publisher/deployment.yaml
+++ b/charts/hyades/templates/notification-publisher/deployment.yaml
@@ -7,8 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.notificationPublisherLabels" .  | nindent 4 }}
 spec:
-  replicas: {{ .Values.notificationPublisher.replicaCount }}
-  strategy: {{- toYaml .Values.notificationPublisher.deployment.strategy | nindent 4 }}
+  {{- if .Values.notificationPublisher.replicas.enabled }}
+  replicas: {{ .Values.notificationPublisher.replicas.replicaCount }}
+  {{- end }}
+  {{- if .Values.notificationPublisher.deployment.strategy.enabled }}
+  strategy:
+    type: {{ .Values.notificationPublisher.deployment.strategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.notificationPublisherSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/notification-publisher/deployment.yaml
+++ b/charts/hyades/templates/notification-publisher/deployment.yaml
@@ -7,13 +7,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.notificationPublisherLabels" .  | nindent 4 }}
 spec:
-  {{- if .Values.notificationPublisher.replicas.enabled }}
-  replicas: {{ .Values.notificationPublisher.replicas.replicaCount }}
+  {{- if (not .Values.notificationPublisher.autoScaling.enabled) }}
+  replicas: {{ .Values.notificationPublisher.replicaCount }}
   {{- end }}
-  {{- if .Values.notificationPublisher.deployment.strategy.enabled }}
   strategy:
     type: {{ .Values.notificationPublisher.deployment.strategy.type }}
-  {{- end }}
   selector:
     matchLabels: {{- include "hyades.notificationPublisherSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/notification-publisher/hpa.yaml
+++ b/charts/hyades/templates/notification-publisher/hpa.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.notificationPublisher.autoScaling.enabled .Values.notificationPublisher.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "hyades.notificationPublisherFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "hyades.notificationPublisherLabels" .  | nindent 4 }}
+  {{- if .Values.notificationPublisher.autoScaling.annotations }}
+  annotations:
+  {{- with .Values.notificationPublisher.autoScaling.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "hyades.notificationPublisherFullname" . }}
+  minReplicas: {{ .Values.notificationPublisher.autoScaling.minReplicas }}
+  maxReplicas: {{ .Values.notificationPublisher.autoScaling.maxReplicas }}
+  metrics:
+    {{- if .Values.notificationPublisher.autoScaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.notificationPublisher.autoScaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.notificationPublisher.autoScaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.notificationPublisher.autoScaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/hyades/templates/repo-meta-analyzer/deployment.yaml
+++ b/charts/hyades/templates/repo-meta-analyzer/deployment.yaml
@@ -7,8 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.repoMetaAnalyzerLabels" .  | nindent 4 }}
 spec:
-  replicas: {{ .Values.repoMetaAnalyzer.replicaCount }}
-  strategy: {{- toYaml .Values.repoMetaAnalyzer.deployment.strategy | nindent 4 }}
+  {{- if .Values.repoMetaAnalyzer.replicas.enabled }}
+  replicas: {{ .Values.repoMetaAnalyzer.replicas.replicaCount }}
+  {{- end }}
+  {{- if .Values.repoMetaAnalyzer.deployment.strategy.enabled }}
+  strategy:
+    type: {{ .Values.repoMetaAnalyzer.deployment.strategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.repoMetaAnalyzerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/repo-meta-analyzer/deployment.yaml
+++ b/charts/hyades/templates/repo-meta-analyzer/deployment.yaml
@@ -7,13 +7,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.repoMetaAnalyzerLabels" .  | nindent 4 }}
 spec:
-  {{- if .Values.repoMetaAnalyzer.replicas.enabled }}
-  replicas: {{ .Values.repoMetaAnalyzer.replicas.replicaCount }}
+  {{- if (not .Values.repoMetaAnalyzer.autoScaling.enabled) }}
+  replicas: {{ .Values.repoMetaAnalyzer.replicaCount }}
   {{- end }}
-  {{- if .Values.repoMetaAnalyzer.deployment.strategy.enabled }}
   strategy:
     type: {{ .Values.repoMetaAnalyzer.deployment.strategy.type }}
-  {{- end }}
   selector:
     matchLabels: {{- include "hyades.repoMetaAnalyzerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/repo-meta-analyzer/hpa.yaml
+++ b/charts/hyades/templates/repo-meta-analyzer/hpa.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.repoMetaAnalyzer.autoScaling.enabled .Values.repoMetaAnalyzer.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "hyades.repoMetaAnalyzerFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "hyades.repoMetaAnalyzerLabels" .  | nindent 4 }}
+  {{- if .Values.repoMetaAnalyzer.autoScaling.annotations }}
+  annotations:
+  {{- with .Values.repoMetaAnalyzer.autoScaling.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "hyades.repoMetaAnalyzerFullname" . }}
+  minReplicas: {{ .Values.repoMetaAnalyzer.autoScaling.minReplicas }}
+  maxReplicas: {{ .Values.repoMetaAnalyzer.autoScaling.maxReplicas }}
+  metrics:
+    {{- if .Values.repoMetaAnalyzer.autoScaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.repoMetaAnalyzer.autoScaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.repoMetaAnalyzer.autoScaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.repoMetaAnalyzer.autoScaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/hyades/templates/vuln-analyzer/deployment.yaml
+++ b/charts/hyades/templates/vuln-analyzer/deployment.yaml
@@ -7,8 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.vulnAnalyzerLabels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.vulnAnalyzer.replicaCount }}
-  strategy: {{- toYaml .Values.vulnAnalyzer.deployment.strategy | nindent 4 }}
+  {{- if .Values.vulnAnalyzer.replicas.enabled }}
+  replicas: {{ .Values.vulnAnalyzer.replicas.replicaCount }}
+  {{- end }}
+  {{- if .Values.vulnAnalyzer.deployment.strategy.enabled }}
+  strategy:
+    type: {{ .Values.vulnAnalyzer.deployment.strategy.type }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.vulnAnalyzerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/vuln-analyzer/deployment.yaml
+++ b/charts/hyades/templates/vuln-analyzer/deployment.yaml
@@ -7,13 +7,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "hyades.vulnAnalyzerLabels" . | nindent 4 }}
 spec:
-  {{- if .Values.vulnAnalyzer.replicas.enabled }}
-  replicas: {{ .Values.vulnAnalyzer.replicas.replicaCount }}
+  {{- if (not .Values.vulnAnalyzer.autoScaling.enabled) }}
+  replicas: {{ .Values.vulnAnalyzer.replicaCount }}
   {{- end }}
-  {{- if .Values.vulnAnalyzer.deployment.strategy.enabled }}
   strategy:
     type: {{ .Values.vulnAnalyzer.deployment.strategy.type }}
-  {{- end }}
   selector:
     matchLabels: {{- include "hyades.vulnAnalyzerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/templates/vuln-analyzer/hpa.yaml
+++ b/charts/hyades/templates/vuln-analyzer/hpa.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.vulnAnalyzer.autoScaling.enabled .Values.vulnAnalyzer.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "hyades.vulnAnalyzerFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "hyades.vulnAnalyzerLabels" . | nindent 4 }}
+  {{- if .Values.vulnAnalyzer.autoScaling.annotations }}
+  annotations:
+  {{- with .Values.vulnAnalyzer.autoScaling.annotations }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    {{- if .Values.vulnAnalyzer.useStatefulSet }}
+    kind: StatefulSet
+    {{- else }}
+    kind: Deployment
+    {{- end }}
+    name: {{ include "hyades.vulnAnalyzerFullname" . }}
+  minReplicas: {{ .Values.vulnAnalyzer.autoScaling.minReplicas }}
+  maxReplicas: {{ .Values.vulnAnalyzer.autoScaling.maxReplicas }}
+  metrics:
+    {{- if .Values.vulnAnalyzer.autoScaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.vulnAnalyzer.autoScaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.vulnAnalyzer.autoScaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.vulnAnalyzer.autoScaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/hyades/templates/vuln-analyzer/statefulset.yaml
+++ b/charts/hyades/templates/vuln-analyzer/statefulset.yaml
@@ -8,7 +8,9 @@ metadata:
   labels: {{- include "hyades.vulnAnalyzerLabels" . | nindent 4 }}
 spec:
   serviceName: {{ include "hyades.vulnAnalyzerFullname" . }}-headless
+  {{- if (not .Values.vulnAnalyzer.autoScaling.enabled) }}
   replicas: {{ .Values.vulnAnalyzer.replicaCount }}
+  {{- end }}
   selector:
     matchLabels: {{- include "hyades.vulnAnalyzerSelectorLabels" . | nindent 6 }}
   template:

--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -28,13 +28,19 @@ common:
 apiServer:
   # -- Whether the API server shall be deployed.
   enabled: true
-  replicas:
-    enabled: true
-    replicaCount: 1
+  # -- Enables horizontal pod autoscaling
+  autoScaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
+  # -- replicaCount is not used when autoscaling is enabled
+  replicaCount: 1
   deployment:
     # -- The deployment strategy to use.
     strategy:
-      enabled: true
       type: RollingUpdate
   annotations: {}
   image: &apiServerImage
@@ -164,13 +170,19 @@ initializer:
 frontend:
   # -- Whether the frontend shall be deployed.
   enabled: true
-  replicas:
-    enabled: true
-    replicaCount: 1
+  # -- Enables horizontal pod autoscaling
+  autoScaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
+  # -- replicaCount is not used when autoscaling is enabled
+  replicaCount: 1
   deployment:
     # -- The deployment strategy to use.
     strategy:
-      enabled: true
       type: RollingUpdate
   annotations: {}
   image:
@@ -289,15 +301,21 @@ mirrorService:
 notificationPublisher:
   # -- Whether the notification publisher shall be deployed.
   enabled: true
-  replicas:
-    enabled: true
-    replicaCount: 1
+  # -- Enables horizontal pod autoscaling
+  autoScaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
+  # -- replicaCount is not used when autoscaling is enabled
+  replicaCount: 1
   deployment:
     # -- The deployment strategy to use. `Recreate` is recommended because the service
     # does not serve user-traffic, and `RollingUpdate` will cause undesired
     # Kafka consumer rebalances.
     strategy:
-      enabled: true
       type: Recreate
   annotations: {}
   image:
@@ -347,15 +365,21 @@ repoMetaAnalyzer:
   # -- Whether the repository metadata analyzer shall be deployed.
   enabled: true
   annotations: {}
-  replicas:
-    enabled: true
-    replicaCount: 1
+  # -- Enables horizontal pod autoscaling
+  autoScaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
+  # -- replicaCount is not used when autoscaling is enabled
+  replicaCount: 1
   deployment:
     # -- The deployment strategy to use. `Recreate` is recommended because the service
     # does not serve user-traffic, and `RollingUpdate` will cause undesired
     # Kafka consumer rebalances.
     strategy:
-      enabled: true
       type: Recreate
   image:
     # -- Override common.image.registry for the repository metadata analyzer.
@@ -409,15 +433,21 @@ vulnAnalyzer:
   # state to disk. Should be used in combination with persistentVolume.enabled.
   useStatefulSet: false
   annotations: {}
-  replicas:
-    enabled: true
-    replicaCount: 1
+  # -- Enables horizontal pod autoscaling
+  autoScaling:
+    enabled: false
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
+  # -- replicaCount is not used when autoscaling is enabled
+  replicaCount: 1
   deployment:
     # -- The deployment strategy to use. `Recreate` is recommended because the service
     # does not serve user-traffic, and `RollingUpdate` will cause undesired
     # Kafka consumer rebalances.
     strategy:
-      enabled: true
       type: Recreate
   image:
     # -- Override common.image.registry for the vulnerability analyzer.

--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -235,15 +235,12 @@ mirrorService:
   # -- Whether the mirror service shall be deployed.
   enabled: true
   # -- Number of replicas. Should be <= 1.
-  replicas:
-    enabled: true
-    replicaCount: 1
+  replicaCount: 1
   deployment:
     # -- The deployment strategy to use. `Recreate` is recommended because the service
     # does not serve user-traffic, and `RollingUpdate` will cause undesired
     # Kafka consumer rebalances.
     strategy:
-      enabled: true
       type: Recreate
   annotations: {}
   image:

--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -28,10 +28,13 @@ common:
 apiServer:
   # -- Whether the API server shall be deployed.
   enabled: true
-  replicaCount: 1
+  replicas:
+    enabled: true
+    replicaCount: 1
   deployment:
     # -- The deployment strategy to use.
     strategy:
+      enabled: true
       type: RollingUpdate
   annotations: {}
   image: &apiServerImage
@@ -161,10 +164,13 @@ initializer:
 frontend:
   # -- Whether the frontend shall be deployed.
   enabled: true
-  replicaCount: 1
+  replicas:
+    enabled: true
+    replicaCount: 1
   deployment:
     # -- The deployment strategy to use.
     strategy:
+      enabled: true
       type: RollingUpdate
   annotations: {}
   image:
@@ -229,12 +235,15 @@ mirrorService:
   # -- Whether the mirror service shall be deployed.
   enabled: true
   # -- Number of replicas. Should be <= 1.
-  replicaCount: 1
+  replicas:
+    enabled: true
+    replicaCount: 1
   deployment:
     # -- The deployment strategy to use. `Recreate` is recommended because the service
     # does not serve user-traffic, and `RollingUpdate` will cause undesired
     # Kafka consumer rebalances.
     strategy:
+      enabled: true
       type: Recreate
   annotations: {}
   image:
@@ -283,12 +292,15 @@ mirrorService:
 notificationPublisher:
   # -- Whether the notification publisher shall be deployed.
   enabled: true
-  replicaCount: 1
+  replicas:
+    enabled: true
+    replicaCount: 1
   deployment:
     # -- The deployment strategy to use. `Recreate` is recommended because the service
     # does not serve user-traffic, and `RollingUpdate` will cause undesired
     # Kafka consumer rebalances.
     strategy:
+      enabled: true
       type: Recreate
   annotations: {}
   image:
@@ -338,12 +350,15 @@ repoMetaAnalyzer:
   # -- Whether the repository metadata analyzer shall be deployed.
   enabled: true
   annotations: {}
-  replicaCount: 1
+  replicas:
+    enabled: true
+    replicaCount: 1
   deployment:
     # -- The deployment strategy to use. `Recreate` is recommended because the service
     # does not serve user-traffic, and `RollingUpdate` will cause undesired
     # Kafka consumer rebalances.
     strategy:
+      enabled: true
       type: Recreate
   image:
     # -- Override common.image.registry for the repository metadata analyzer.
@@ -397,12 +412,15 @@ vulnAnalyzer:
   # state to disk. Should be used in combination with persistentVolume.enabled.
   useStatefulSet: false
   annotations: {}
-  replicaCount: 1
+  replicas:
+    enabled: true
+    replicaCount: 1
   deployment:
     # -- The deployment strategy to use. `Recreate` is recommended because the service
     # does not serve user-traffic, and `RollingUpdate` will cause undesired
     # Kafka consumer rebalances.
     strategy:
+      enabled: true
       type: Recreate
   image:
     # -- Override common.image.registry for the vulnerability analyzer.


### PR DESCRIPTION
Enable turning off/on the `replica` and `strategy.type` fields in deployment manifests so that HPAs can be configured for Hyades