### PR TITLE
`serviceAccount` -> `serviceAccountName`

### DIFF
--- a/charts/dependency-track/templates/api-server/deployment.yaml
+++ b/charts/dependency-track/templates/api-server/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- with .Values.apiServer.initContainers }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
-      serviceAccount: {{ include "dependencytrack.serviceAccountName" . }}
+      serviceAccountName: {{ include "dependencytrack.serviceAccountName" . }}
       {{- with .Values.apiServer.podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       {{- with .Values.frontend.initContainers }}
       {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
-      serviceAccount: {{ include "dependencytrack.serviceAccountName" . }}
+      serviceAccountName: {{ include "dependencytrack.serviceAccountName" . }}
       containers:
       - name: {{ include "dependencytrack.frontendName" . }}
         image: {{ include "dependencytrack.frontendImage" . }}


### PR DESCRIPTION
According to the Kubernetes [documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) the service account should be referenced via `serviceAccountName`