### PR TITLE
Additional volumes didnt get attached properly to deployment

### DIFF
--- a/charts/dependency-track/templates/api-server/deployment.yaml
+++ b/charts/dependency-track/templates/api-server/deployment.yaml
@@ -118,6 +118,9 @@ spec:
         {{- end }}
       - name: tmp
         emptyDir: { }
+      {{- if .Values.apiServer.additionalVolumes }}
+        {{- toYaml .Values.apiServer.additionalVolumes | nindent 6 }}
+      {{- end }}
       {{- with (include "dependencytrack.secretKeySecretName" .) }}
       - name: secret-key
         secret:


### PR DESCRIPTION
The template for the API deployment didn't include additional volumes even if you declare them in the respective part of the values.yaml file. This PR adds the missing templating so additional volumes can now be attached.