### PR TITLE
feat(apiServer): add ability to disable Prometheus metrics scraping

### DIFF
--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -36,6 +36,7 @@ that allows organizations to identify and reduce risk in the software supply cha
 | apiServer.image.repository | string | `"dependencytrack/apiserver"` |  |
 | apiServer.image.tag | string | `""` | Can be a tag name such as "latest", or an image digest prefixed with "sha256:". Defaults to AppVersion of the chart. |
 | apiServer.initContainers | list | `[]` | Additional init containers to deploy. Supports templating. |
+| apiServer.metrics.enabled | bool | `true` | Enable Prometheus scraping annotations on pods |
 | apiServer.nodeSelector | object | `{}` |  |
 | apiServer.persistentVolume.className | string | `""` |  |
 | apiServer.persistentVolume.enabled | bool | `false` |  |
@@ -116,4 +117,3 @@ that allows organizations to identify and reduce risk in the software supply cha
 | ingress.hostname | string | `"example.com"` |  |
 | ingress.ingressClassName | string | `""` |  |
 | ingress.tls | list | `[]` |  |
-

--- a/charts/dependency-track/ci/test-values.yaml
+++ b/charts/dependency-track/ci/test-values.yaml
@@ -13,3 +13,5 @@ apiServer:
   extraEnv:
     - name: SYSTEM_REQUIREMENT_CHECK_ENABLED
       value: "false"
+  metrics:
+    enabled: false

--- a/charts/dependency-track/templates/api-server/deployment.yaml
+++ b/charts/dependency-track/templates/api-server/deployment.yaml
@@ -17,8 +17,10 @@ spec:
       {{- toYaml .Values.apiServer.extraPodLabels | nindent 8 }}
       {{- end }}
       annotations:
+        {{- if .Values.apiServer.metrics.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/path: /metrics
+        {{- end }}
         {{- with .Values.apiServer.annotations }}
         {{ toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/dependency-track/templates/api-server/statefulset.yaml
+++ b/charts/dependency-track/templates/api-server/statefulset.yaml
@@ -18,8 +18,10 @@ spec:
       {{- toYaml .Values.apiServer.extraPodLabels | nindent 8 }}
       {{- end }}
       annotations:
+        {{- if .Values.apiServer.metrics.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/path: /metrics
+        {{- end }}
         {{- with .Values.apiServer.annotations }}
         {{ toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/dependency-track/values.schema.json
+++ b/charts/dependency-track/values.schema.json
@@ -68,6 +68,14 @@
         "annotations": {
           "type": "object"
         },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
+        },
         "image": {
           "$ref": "#/$defs/image"
         },

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -23,6 +23,9 @@ apiServer:
 # -- The type of deployment. Can be either Deployment or StatefulSet.
   deploymentType: StatefulSet
   annotations: {}
+  metrics:
+    # -- Enable Prometheus scraping annotations on pods
+    enabled: true
   image:
     # -- Override common.image.registry for the API server.
     registry: ''


### PR DESCRIPTION
This change adds a new configuration option `apiServer.metrics.enabled` (boolean, defaults to `true`) that controls whether Prometheus scraping annotations are applied to the API server pods.

This gives users more control over their monitoring setup and allows them to disable Prometheus metrics collection if needed.

Closes #228