### PR TITLE
Allow disabling service links

### DIFF
--- a/charts/dependency-track/templates/api-server/deployment.yaml
+++ b/charts/dependency-track/templates/api-server/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{ toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      enableServiceLinks: {{ .Values.common.serviceLinks }}
+      enableServiceLinks: {{ .Values.common.enableServiceLinks }}
       {{- with .Values.common.image.pullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/dependency-track/templates/api-server/deployment.yaml
+++ b/charts/dependency-track/templates/api-server/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         {{ toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      enableServiceLinks: {{ .Values.common.serviceLinks }}
       {{- with .Values.common.image.pullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/dependency-track/templates/api-server/statefulset.yaml
+++ b/charts/dependency-track/templates/api-server/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
         {{ toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      enableServiceLinks: {{ .Values.common.serviceLinks }}
+      enableServiceLinks: {{ .Values.common.enableServiceLinks }}
       {{- with .Values.common.image.pullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/dependency-track/templates/api-server/statefulset.yaml
+++ b/charts/dependency-track/templates/api-server/statefulset.yaml
@@ -26,6 +26,7 @@ spec:
         {{ toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      enableServiceLinks: {{ .Values.common.serviceLinks }}
       {{- with .Values.common.image.pullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      enableServiceLinks: {{ .Values.common.serviceLinks }}
       {{- with .Values.common.image.pullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/dependency-track/templates/frontend/deployment.yaml
+++ b/charts/dependency-track/templates/frontend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      enableServiceLinks: {{ .Values.common.serviceLinks }}
+      enableServiceLinks: {{ .Values.common.enableServiceLinks }}
       {{- with .Values.common.image.pullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/dependency-track/values.schema.json
+++ b/charts/dependency-track/values.schema.json
@@ -53,6 +53,9 @@
               "type": "boolean"
             }
           }
+        },
+        "enableServiceLinks": {
+          "type": "boolean"
         }
       }
     },

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -18,6 +18,8 @@ common:
     name: ""
     # -- Whether the serviceAccount should mount the token.
     automount: false
+  # -- Whether service links should be added to the Pods
+  serviceLinks: true
 
 apiServer:
 # -- The type of deployment. Can be either Deployment or StatefulSet.

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -19,7 +19,7 @@ common:
     # -- Whether the serviceAccount should mount the token.
     automount: false
   # -- Whether service links should be added to the Pods
-  serviceLinks: true
+  enableServiceLinks: true
 
 apiServer:
 # -- The type of deployment. Can be either Deployment or StatefulSet.


### PR DESCRIPTION
This feature allows disabling Kubernetes service links, because the frontend fails to start on large Kubernetes namespaces with a lot of services (~ 375) with the message:

```
/docker-entrypoint.d/20-envsubst-on-templates.sh: line 53: envsubst: Argument list too long
```

To disable service links, add this to your `values.yaml`:
```yaml
common:
  serviceLinks: false
```

The documentation (https://kubernetes.io/docs/tutorials/services/connect-applications-service/) states:
> If the service environment variables are not desired (because possible clashing with expected program ones, too many variables to process, only using DNS, etc) you can disable this mode by setting the enableServiceLinks flag to false on the pod spec.