### PR TITLE
Support startup probe for API server

### DIFF
--- a/charts/dependency-track/templates/api-server/deployment.yaml
+++ b/charts/dependency-track/templates/api-server/deployment.yaml
@@ -80,6 +80,16 @@ spec:
         {{- if .Values.apiServer.additionalVolumeMounts }}
           {{- toYaml .Values.apiServer.additionalVolumeMounts | nindent 8 }}
         {{- end }}
+        startupProbe:
+          httpGet:
+            scheme: HTTP
+            port: web
+            path: /health/started
+          failureThreshold: {{ .Values.apiServer.probes.startup.failureThreshold }}
+          initialDelaySeconds: {{ .Values.apiServer.probes.startup.initialDelaySeconds }}
+          periodSeconds: {{ .Values.apiServer.probes.startup.periodSeconds }}
+          successThreshold: {{ .Values.apiServer.probes.startup.successThreshold }}
+          timeoutSeconds: {{ .Values.apiServer.probes.startup.timeoutSeconds }}
         livenessProbe:
           httpGet:
             scheme: HTTP

--- a/charts/dependency-track/values.schema.json
+++ b/charts/dependency-track/values.schema.json
@@ -297,6 +297,9 @@
     "probes": {
       "type": "object",
       "properties": {
+        "startup": {
+          "$ref": "#/$defs/probe"
+        },
         "readiness": {
           "$ref": "#/$defs/probe"
         },

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -79,6 +79,12 @@ apiServer:
   extraPodLabels: {}
   tolerations: []
   probes:
+    startup:
+      failureThreshold: 30
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 5
     liveness:
       failureThreshold: 3
       initialDelaySeconds: 10


### PR DESCRIPTION
Because database migrations are executed on startup, the container may be unresponsive for an extended period of time when deploying a new version. This can cause k8s to repeatedly kill the Pod before upgrades can complete.

This change adds support for startup probes, and grants the container 5min per default to complete any startup sequences.

Relates to https://github.com/DependencyTrack/dependency-track/issues/5400