### PR TITLE
feat(startup probe): enable for the stateful set

### DIFF
--- a/charts/dependency-track/templates/api-server/statefulset.yaml
+++ b/charts/dependency-track/templates/api-server/statefulset.yaml
@@ -81,6 +81,16 @@ spec:
         {{- if .Values.apiServer.additionalVolumeMounts }}
           {{- toYaml .Values.apiServer.additionalVolumeMounts | nindent 8 }}
         {{- end }}
+        startupProbe:
+          httpGet:
+            scheme: HTTP
+            port: web
+            path: /health/started
+          failureThreshold: {{ .Values.apiServer.probes.startup.failureThreshold }}
+          initialDelaySeconds: {{ .Values.apiServer.probes.startup.initialDelaySeconds }}
+          periodSeconds: {{ .Values.apiServer.probes.startup.periodSeconds }}
+          successThreshold: {{ .Values.apiServer.probes.startup.successThreshold }}
+          timeoutSeconds: {{ .Values.apiServer.probes.startup.timeoutSeconds }}
         livenessProbe:
           httpGet:
             scheme: HTTP


### PR DESCRIPTION
Port the startupProbe feature from #267 to the StatefulSet.

Relates to https://github.com/DependencyTrack/dependency-track/issues/5400