### PR TITLE
Bump dependency-track chart version to 1.0.0

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dependency-track
-version: 0.46.0
+version: 1.0.0
 type: application
 appVersion: 4.14.2
 description: |-


### PR DESCRIPTION
No functional change. This is only to establish a stable baseline from which we can ship changes compatible with Dependency-Track v4. We'll release a v5-compatbile chart as 2.0.0 later.