### PR TITLE
Fix: Render explicit HTTPRoute backendRef defaults

### DIFF
--- a/charts/dependency-track/templates/httproute.yaml
+++ b/charts/dependency-track/templates/httproute.yaml
@@ -24,27 +24,39 @@ spec:
         type: PathPrefix
         value: /api
     backendRefs:
-    - name: {{ include "dependencytrack.apiServerFullname" . }}
+    - group: ""
+      kind: Service
+      name: {{ include "dependencytrack.apiServerFullname" . }}
       port: 8080
+      weight: 1
   - matches:
     - path:
         type: PathPrefix
         value: /health
     backendRefs:
-    - name: {{ include "dependencytrack.apiServerFullname" . }}
+    - group: ""
+      kind: Service
+      name: {{ include "dependencytrack.apiServerFullname" . }}
       port: 8080
+      weight: 1
   - matches:
     - path:
         type: PathPrefix
         value: /mirror
     backendRefs:
-    - name: {{ include "dependencytrack.apiServerFullname" . }}
+    - group: ""
+      kind: Service
+      name: {{ include "dependencytrack.apiServerFullname" . }}
       port: 8080
+      weight: 1
   - matches:
     - path:
         type: PathPrefix
         value: /
     backendRefs:
-    - name: {{ include "dependencytrack.frontendFullname" . }}
+    - group: ""
+      kind: Service
+      name: {{ include "dependencytrack.frontendFullname" . }}
       port: 8080
+      weight: 1
 {{- end }}

--- a/charts/hyades/templates/httproute.yaml
+++ b/charts/hyades/templates/httproute.yaml
@@ -25,15 +25,21 @@ spec:
         type: PathPrefix
         value: /api
     backendRefs:
-    - name: {{ include "hyades.apiServerFullname" . }}
+    - group: ""
+      kind: Service
+      name: {{ include "hyades.apiServerFullname" . }}
       port: {{ .Values.apiServer.service.port }}
+      weight: 1
   - matches:
     - path:
         type: PathPrefix
         value: /health
     backendRefs:
-    - name: {{ include "hyades.apiServerFullname" . }}
+    - group: ""
+      kind: Service
+      name: {{ include "hyades.apiServerFullname" . }}
       port: {{ .Values.apiServer.service.port }}
+      weight: 1
   {{- end }}
   {{- if .Values.frontend.enabled }}
   - matches:
@@ -41,7 +47,10 @@ spec:
         type: PathPrefix
         value: /
     backendRefs:
-    - name: {{ include "hyades.frontendFullname" . }}
+    - group: ""
+      kind: Service
+      name: {{ include "hyades.frontendFullname" . }}
       port: {{ .Values.frontend.service.port }}
+      weight: 1
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Render Gateway API `HTTPRoute` backendRef defaults explicitly.
Kubernetes defaults `backendRefs[].group`, `backendRefs[].kind`, and `backendRefs[].weight` to:
```yaml
group: ""
kind: Service
weight: 1
```

Because those defaults are persisted in the live object, GitOps tools such as Argo CD can report the rendered chart as drifted even though the route is functionally correct.

screenshot from Argo CD:
<img width="1756" height="995" alt="image" src="https://github.com/user-attachments/assets/045036b0-e53e-4c30-9431-77d04ccf0a3c" />
