### PR TITLE
Add fail-fast check when trying to use chart v1 with Dependency-Track v5

### DIFF
--- a/charts/dependency-track/Chart.yaml
+++ b/charts/dependency-track/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dependency-track
-version: 1.0.0
+version: 1.1.0
 type: application
 appVersion: 4.14.2
 description: |-

--- a/charts/dependency-track/templates/_helpers.tpl
+++ b/charts/dependency-track/templates/_helpers.tpl
@@ -83,10 +83,14 @@ API server fully qualified name
 API server image
 */}}
 {{- define "dependencytrack.apiServerImage" -}}
-{{- if eq (substr 0 7 .Values.apiServer.image.tag) "sha256:" -}}
-{{- printf "%s/%s@%s" (.Values.apiServer.image.registry | default .Values.common.image.registry) .Values.apiServer.image.repository .Values.apiServer.image.tag -}}
+{{- $tag := .Values.apiServer.image.tag | default .Chart.AppVersion -}}
+{{- if and (ne (substr 0 7 $tag) "sha256:") (regexMatch "^5\\..*" $tag) -}}
+{{- fail (printf "apiServer.image.tag %q is not supported by this chart version" $tag) -}}
+{{- end -}}
+{{- if eq (substr 0 7 $tag) "sha256:" -}}
+{{- printf "%s/%s@%s" (.Values.apiServer.image.registry | default .Values.common.image.registry) .Values.apiServer.image.repository $tag -}}
 {{- else -}}
-{{- printf "%s/%s:%s" (.Values.apiServer.image.registry | default .Values.common.image.registry) .Values.apiServer.image.repository (.Values.apiServer.image.tag | default .Chart.AppVersion) -}}
+{{- printf "%s/%s:%s" (.Values.apiServer.image.registry | default .Values.common.image.registry) .Values.apiServer.image.repository $tag -}}
 {{- end -}}
 {{- end -}}
 
@@ -127,10 +131,14 @@ Frontend fully qualified name
 Frontend image
 */}}
 {{- define "dependencytrack.frontendImage" -}}
-{{- if eq (substr 0 7 .Values.frontend.image.tag) "sha256:" -}}
-{{- printf "%s/%s@%s" (.Values.frontend.image.registry | default .Values.common.image.registry) .Values.frontend.image.repository .Values.frontend.image.tag -}}
+{{- $tag := .Values.frontend.image.tag | default .Chart.AppVersion -}}
+{{- if and (ne (substr 0 7 $tag) "sha256:") (regexMatch "^5\\..*" $tag) -}}
+{{- fail (printf "frontend.image.tag %q is not supported by this chart version" $tag) -}}
+{{- end -}}
+{{- if eq (substr 0 7 $tag) "sha256:" -}}
+{{- printf "%s/%s@%s" (.Values.frontend.image.registry | default .Values.common.image.registry) .Values.frontend.image.repository $tag -}}
 {{- else -}}
-{{- printf "%s/%s:%s" (.Values.frontend.image.registry | default .Values.common.image.registry) .Values.frontend.image.repository (.Values.frontend.image.tag | default .Chart.AppVersion) -}}
+{{- printf "%s/%s:%s" (.Values.frontend.image.registry | default .Values.common.image.registry) .Values.frontend.image.repository $tag -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
The chart is not compatible with DT v5. The v5-compatible chart will bump a major version. This is just a safety mechanism to prevent accidental breakage of deployments when users blindly bump the DT version.

Note that this does not and can not catch cases where v5 images are referenced by sha256 digest.