### PR TITLE
Allow setting extra labels to API-server and frontend deployment resources

### DIFF
--- a/charts/hyades/README.md
+++ b/charts/hyades/README.md
@@ -38,6 +38,7 @@ Before upgrading, please consult the [upgrade guides](https://dependencytrack.gi
 | apiServer.extraContainers | list | `[]` | Additional containers to deploy. Supports templating. |
 | apiServer.extraEnv | list | `[]` |  |
 | apiServer.extraEnvFrom | list | `[]` |  |
+| apiServer.extraLabels | object | `{}` | Additional labels to add to the API-service deployment. |
 | apiServer.image.pullPolicy | string | `"Always"` |  |
 | apiServer.image.registry | string | `""` | Override common.image.registry for the API server. |
 | apiServer.image.repository | string | `"dependencytrack/apiserver"` |  |
@@ -98,6 +99,7 @@ Before upgrading, please consult the [upgrade guides](https://dependencytrack.gi
 | frontend.extraContainers | list | `[]` | Additional containers to deploy. Supports templating. |
 | frontend.extraEnv | list | `[]` |  |
 | frontend.extraEnvFrom | list | `[]` |  |
+| frontend.extraLabels | object | `{}` | Additional labels to add to the frontend deployment. |
 | frontend.image.pullPolicy | string | `"Always"` |  |
 | frontend.image.registry | string | `""` | Override common.image.registry for the API frontend. |
 | frontend.image.repository | string | `"dependencytrack/frontend"` |  |

--- a/charts/hyades/templates/api-server/deployment.yaml
+++ b/charts/hyades/templates/api-server/deployment.yaml
@@ -17,6 +17,9 @@ spec:
   template:
     metadata:
       labels: {{ include "hyades.apiServerSelectorLabels" . | nindent 8 }}
+      {{- if .Values.apiServer.extraLabels }}
+      {{- toYaml .Values.apiServer.extraLabels | nindent 8 }}
+      {{- end }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: /metrics

--- a/charts/hyades/templates/frontend/deployment.yaml
+++ b/charts/hyades/templates/frontend/deployment.yaml
@@ -17,6 +17,9 @@ spec:
   template:
     metadata:
       labels: {{- include "hyades.frontendSelectorLabels" . | nindent 8 }}
+      {{- if .Values.frontend.extraLabels }}
+      {{- toYaml .Values.frontend.extraLabels | nindent 8 }}
+      {{- end }}
       {{- with .Values.frontend.annotations }}
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/hyades/values.schema.json
+++ b/charts/hyades/values.schema.json
@@ -106,6 +106,9 @@
         "extraEnvFrom": {
           "$ref": "#/$defs/objectArray"
         },
+        "extraLabels": {
+          "type": "object"
+        },
         "extraContainers": {
           "$ref": "#/$defs/objectArray"
         },
@@ -236,6 +239,9 @@
         },
         "extraEnvFrom": {
           "$ref": "#/$defs/objectArray"
+        },
+        "extraLabels": {
+          "type": "object"
         },
         "extraContainers": {
           "$ref": "#/$defs/objectArray"

--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -63,6 +63,7 @@ apiServer:
       type: RuntimeDefault
   extraEnv: []
   extraEnvFrom: []
+  extraLabels: {}
   probes:
     startup:
       failureThreshold: 30
@@ -210,6 +211,7 @@ frontend:
       type: RuntimeDefault
   extraEnv: []
   extraEnvFrom: []
+  extraLabels: {}
   probes:
     liveness:
       failureThreshold: 3


### PR DESCRIPTION
Implements https://github.com/DependencyTrack/helm-charts/issues/355.

Credits to @initharrington for adding initial support for extra labels in https://github.com/DependencyTrack/helm-charts/pull/166. This PR ports his changes to the hyades helm chart.