### PR TITLE
Fix service monitor related warnings

### DIFF
--- a/charts/hyades/templates/api-server/servicemonitor.yaml
+++ b/charts/hyades/templates/api-server/servicemonitor.yaml
@@ -16,6 +16,6 @@ spec:
   endpoints:
   - port: web
     path: /metrics
-    interval: {{ .Values.apiServer.serviceMonitor.scrapeInternal }}
+    interval: {{ .Values.apiServer.serviceMonitor.scrapeInterval }}
     timeout: {{ .Values.apiServer.serviceMonitor.scrapeTimeout }}
 {{- end }}

--- a/charts/hyades/templates/api-server/servicemonitor.yaml
+++ b/charts/hyades/templates/api-server/servicemonitor.yaml
@@ -17,5 +17,5 @@ spec:
   - port: web
     path: /metrics
     interval: {{ .Values.apiServer.serviceMonitor.scrapeInterval }}
-    timeout: {{ .Values.apiServer.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.apiServer.serviceMonitor.scrapeTimeout }}
 {{- end }}

--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -91,7 +91,7 @@ apiServer:
     enabled: false
     namespace: monitoring
     scrapeInterval: 15s
-    scrapeTimeout: 30s
+    scrapeTimeout: 10s
   # -- Grace period for pod termination in seconds.
   # Should always be equal to or greater than the sum of `_DRAIN_TIMEOUT` configurations to ensure graceful shutdown.
   # Refer to https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/ for details.

--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -90,7 +90,7 @@ apiServer:
   serviceMonitor:
     enabled: false
     namespace: monitoring
-    scrapeInternal: 15s
+    scrapeInterval: 15s
     scrapeTimeout: 30s
   # -- Grace period for pod termination in seconds.
   # Should always be equal to or greater than the sum of `_DRAIN_TIMEOUT` configurations to ensure graceful shutdown.


### PR DESCRIPTION
Thanks for working on Dependency-Track. While deploying DT 5 with the Helm chart here, I encountered a few warnings in my log related to this chart. This PR fixes those.

The fixes:
* `values.yaml` accepted a value `scrapeInternal` that should be `scrapeInterval` (simple typo)
* `values.yaml` by default set `scrapeInterval` to be higher than `scrapeTimeout`, but it should be lower or Prometheus won't accept it.
* The key in the ServiceMonitor endpoints configuration is `timeout` but it should be `scrapeTimeout` to be accepted by Prometheus. This is a rehash of #170 but now for DT v5.