### PR TITLE
feat(hyades): separate Job and Pod metadata for initializer

### DIFF
--- a/charts/hyades/README.md
+++ b/charts/hyades/README.md
@@ -31,7 +31,7 @@ v2, or be ready to migrate when v2 is released.
 |-----|------|---------|-------------|
 | apiServer.additionalVolumeMounts | list | `[]` |  |
 | apiServer.additionalVolumes | list | `[]` |  |
-| apiServer.annotations | object | `{}` |  |
+| apiServer.annotations | object | `{}` | Additional annotations to add to the API-server Deployment resource. |
 | apiServer.args | list | `[]` |  |
 | apiServer.autoScaling | object | `{"annotations":{},"enabled":false,"maxReplicas":3,"minReplicas":1,"targetCPUUtilizationPercentage":70,"targetMemoryUtilizationPercentage":70}` | Enables horizontal pod autoscaling |
 | apiServer.command | list | `[]` |  |
@@ -40,18 +40,20 @@ v2, or be ready to migrate when v2 is released.
 | apiServer.extraContainers | list | `[]` | Additional containers to deploy. Supports templating. |
 | apiServer.extraEnv | list | `[]` |  |
 | apiServer.extraEnvFrom | list | `[]` |  |
-| apiServer.extraLabels | object | `{}` |  |
 | apiServer.image.pullPolicy | string | `"Always"` |  |
 | apiServer.image.registry | string | `""` | Override common.image.registry for the API server. |
 | apiServer.image.repository | string | `"dependencytrack/apiserver"` |  |
 | apiServer.image.tag | string | `""` | Can be a tag name such as "latest", or an image digest prefixed with "sha256:". |
 | apiServer.initContainers | list | `[]` | Additional init containers to deploy. Supports templating. |
+| apiServer.labels | object | `{}` | Additional labels to add to the API-server Deployment resource. |
 | apiServer.nodeSelector | object | `{}` |  |
 | apiServer.persistentVolume.accessModes | list | `[]` | Access modes for the PVC. When empty, access modes are determined automatically: - ReadWriteMany when autoScaling is enabled or replicaCount > 1 - ReadWriteOnce otherwise |
 | apiServer.persistentVolume.className | string | `""` | Storage class name. If empty, the default storage class will be used. |
 | apiServer.persistentVolume.enabled | bool | `false` | Whether to create a PersistentVolumeClaim for the API server. |
 | apiServer.persistentVolume.existingClaim | string | `""` | Use an existing PVC instead of creating a new one. When set, the PVC will not be created by the chart. |
 | apiServer.persistentVolume.size | string | `"5Gi"` | Size of the PVC. |
+| apiServer.podAnnotations | object | `{}` | Additional annotations to add to the API-server pods. |
+| apiServer.podLabels | object | `{}` | Additional labels to add to the API-server pods. |
 | apiServer.probes.liveness.failureThreshold | int | `3` |  |
 | apiServer.probes.liveness.initialDelaySeconds | int | `10` |  |
 | apiServer.probes.liveness.periodSeconds | int | `15` |  |
@@ -97,7 +99,7 @@ v2, or be ready to migrate when v2 is released.
 | extraObjects | list | `[]` |  |
 | frontend.additionalVolumeMounts | list | `[]` |  |
 | frontend.additionalVolumes | list | `[]` |  |
-| frontend.annotations | object | `{}` |  |
+| frontend.annotations | object | `{}` | Additional annotations to add to the frontend Deployment resource. |
 | frontend.apiBaseUrl | string | `""` |  |
 | frontend.args | list | `[]` |  |
 | frontend.autoScaling | object | `{"annotations":{},"enabled":false,"maxReplicas":3,"minReplicas":1,"targetCPUUtilizationPercentage":70,"targetMemoryUtilizationPercentage":70}` | Enables horizontal pod autoscaling |
@@ -107,13 +109,15 @@ v2, or be ready to migrate when v2 is released.
 | frontend.extraContainers | list | `[]` | Additional containers to deploy. Supports templating. |
 | frontend.extraEnv | list | `[]` |  |
 | frontend.extraEnvFrom | list | `[]` |  |
-| frontend.extraLabels | object | `{}` |  |
 | frontend.image.pullPolicy | string | `"Always"` |  |
 | frontend.image.registry | string | `""` | Override common.image.registry for the API frontend. |
 | frontend.image.repository | string | `"dependencytrack/frontend"` |  |
 | frontend.image.tag | string | `""` | Can be a tag name such as "latest", or an image digest prefixed with "sha256:". |
 | frontend.initContainers | list | `[]` | Additional init containers to deploy. Supports templating. |
+| frontend.labels | object | `{}` | Additional labels to add to the frontend Deployment resource. |
 | frontend.nodeSelector | object | `{}` |  |
+| frontend.podAnnotations | object | `{}` | Additional annotations to add to the frontend pods. |
+| frontend.podLabels | object | `{}` | Additional labels to add to the frontend pods. |
 | frontend.probes.liveness.failureThreshold | int | `3` |  |
 | frontend.probes.liveness.initialDelaySeconds | int | `5` |  |
 | frontend.probes.liveness.periodSeconds | int | `15` |  |
@@ -144,7 +148,7 @@ v2, or be ready to migrate when v2 is released.
 | ingress.hostname | string | `"example.com"` |  |
 | ingress.ingressClassName | string | `""` |  |
 | ingress.tls | list | `[]` |  |
-| initializer.annotations | object | `{}` |  |
+| initializer.annotations | object | `{}` | Additional annotations to add to the initializer Job resource. |
 | initializer.args | list | `[]` |  |
 | initializer.command | list | `[]` |  |
 | initializer.enabled | bool | `false` | Whether to enable the initializer Job. When enabled, an init container will be added to all deployments that require database access. The init container will wait for the initializer Job to complete. Requires the service account token to be mounted. |
@@ -154,8 +158,11 @@ v2, or be ready to migrate when v2 is released.
 | initializer.image.registry | string | `""` | Override common.image.registry for the API server. |
 | initializer.image.repository | string | `"dependencytrack/apiserver"` |  |
 | initializer.image.tag | string | `""` | Can be a tag name such as "latest", or an image digest prefixed with "sha256:". |
+| initializer.labels | object | `{}` | Additional labels to add to the initializer Job resource. |
 | initializer.noHelmHook | bool | `false` | Whether to NOT deploy the initializer Job as `post-install` and `post-upgrade` Helm hook. Deploying as Helm hook can create deadlock situations when `helm install` and `helm upgrade` are executed with `--wait` flag. See <https://github.com/helm/helm/issues/10555>. Note that without hooks, `helm upgrade` may fail due to Job fields being immutable. |
 | initializer.nodeSelector | object | `{}` |  |
+| initializer.podAnnotations | object | `{}` | Additional annotations to add to the initializer pods. |
+| initializer.podLabels | object | `{}` | Additional labels to add to the initializer pods. |
 | initializer.resources.limits.memory | string | `"256Mi"` |  |
 | initializer.resources.requests.cpu | string | `"150m"` |  |
 | initializer.resources.requests.memory | string | `"256Mi"` |  |
@@ -167,3 +174,5 @@ v2, or be ready to migrate when v2 is released.
 | initializer.waiter.image.repository | string | `"bitnami/kubectl"` |  |
 | initializer.waiter.image.tag | string | `"latest"` |  |
 
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/hyades/templates/api-server/deployment.yaml
+++ b/charts/hyades/templates/api-server/deployment.yaml
@@ -5,7 +5,15 @@ kind: Deployment
 metadata:
   name: {{ include "hyades.apiServerFullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "hyades.apiServerLabels" . | nindent 4 }}
+  {{- with .Values.apiServer.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "hyades.apiServerLabels" . | nindent 4 }}
+    {{- with .Values.apiServer.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if (not .Values.apiServer.autoScaling.enabled) }}
   replicas: {{ .Values.apiServer.replicaCount }}
@@ -16,15 +24,16 @@ spec:
     matchLabels: {{- include "hyades.apiServerSelectorLabels" . | nindent 6 }}
   template:
     metadata:
-      labels: {{ include "hyades.apiServerSelectorLabels" . | nindent 8 }}
-      {{- if .Values.apiServer.extraLabels }}
-      {{- toYaml .Values.apiServer.extraLabels | nindent 8 }}
-      {{- end }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: /metrics
-        {{- with .Values.apiServer.annotations }}
+        {{- with .Values.apiServer.podAnnotations }}
         {{ toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "hyades.apiServerSelectorLabels" . | nindent 8 }}
+        {{- with .Values.apiServer.podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.common.image.pullSecrets }}

--- a/charts/hyades/templates/frontend/deployment.yaml
+++ b/charts/hyades/templates/frontend/deployment.yaml
@@ -5,7 +5,15 @@ kind: Deployment
 metadata:
   name: {{ include "hyades.frontendFullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "hyades.frontendLabels" . | nindent 4 }}
+  {{- with .Values.frontend.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "hyades.frontendLabels" . | nindent 4 }}
+    {{- with .Values.frontend.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if (not .Values.frontend.autoScaling.enabled) }}
   replicas: {{ .Values.frontend.replicaCount }}
@@ -16,13 +24,15 @@ spec:
     matchLabels: {{- include "hyades.frontendSelectorLabels" . | nindent 6 }}
   template:
     metadata:
-      labels: {{- include "hyades.frontendSelectorLabels" . | nindent 8 }}
-      {{- if .Values.frontend.extraLabels }}
-      {{- toYaml .Values.frontend.extraLabels | nindent 8 }}
+      {{- with .Values.frontend.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.frontend.annotations }}
-      annotations: {{- toYaml . | nindent 8 }}
-      {{- end }}
+      labels:
+        {{- include "hyades.frontendSelectorLabels" . | nindent 8 }}
+        {{- with .Values.frontend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.common.image.pullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 6 }}

--- a/charts/hyades/templates/initializer/job.yaml
+++ b/charts/hyades/templates/initializer/job.yaml
@@ -5,18 +5,35 @@ kind: Job
 metadata:
   name: {{ include "hyades.initializerFullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{- include "hyades.initializerLabels" . | nindent 4 }}
-  {{- if not .Values.initializer.noHelmHook }}
+  {{- if or (not .Values.initializer.noHelmHook) .Values.initializer.annotations }}
   annotations:
+    {{- if not .Values.initializer.noHelmHook }}
     "helm.sh/hook": "post-install, post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
+    {{- end }}
+    {{- with .Values.initializer.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- if or (include "hyades.initializerLabels" . | trim) .Values.initializer.labels }}
+  labels:
+    {{- include "hyades.initializerLabels" . | nindent 4 }}
+    {{- with .Values.initializer.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   template:
     metadata:
-      labels: {{- include "hyades.initializerSelectorLabels" . | nindent 8 }}
-      {{- with .Values.initializer.annotations }}
+      {{- with .Values.initializer.podAnnotations }}
       annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or (include "hyades.initializerSelectorLabels" . | trim) .Values.initializer.podLabels }}
+      labels:
+        {{- include "hyades.initializerSelectorLabels" . | nindent 8 }}
+        {{- with .Values.initializer.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
     spec:
       restartPolicy: Never

--- a/charts/hyades/values.schema.json
+++ b/charts/hyades/values.schema.json
@@ -76,7 +76,16 @@
             }
           }
         },
+        "labels": {
+          "type": "object"
+        },
         "annotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podAnnotations": {
           "type": "object"
         },
         "image": {
@@ -105,9 +114,6 @@
         },
         "extraEnvFrom": {
           "$ref": "#/$defs/objectArray"
-        },
-        "extraLabels": {
-          "type": "object"
         },
         "extraContainers": {
           "$ref": "#/$defs/objectArray"
@@ -164,7 +170,19 @@
         "enabled": {
           "type": "boolean"
         },
+        "noHelmHook": {
+          "type": "boolean"
+        },
+        "labels": {
+          "type": "object"
+        },
         "annotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podAnnotations": {
           "type": "object"
         },
         "image": {
@@ -230,7 +248,16 @@
             }
           }
         },
+        "labels": {
+          "type": "object"
+        },
         "annotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "podAnnotations": {
           "type": "object"
         },
         "image": {
@@ -259,9 +286,6 @@
         },
         "extraEnvFrom": {
           "$ref": "#/$defs/objectArray"
-        },
-        "extraLabels": {
-          "type": "object"
         },
         "extraContainers": {
           "$ref": "#/$defs/objectArray"

--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -34,7 +34,14 @@ apiServer:
     # -- The deployment strategy to use.
     strategy:
       type: RollingUpdate
+  # -- Additional labels to add to the API-server Deployment resource.
+  labels: {}
+  # -- Additional annotations to add to the API-server Deployment resource.
   annotations: {}
+  # -- Additional labels to add to the API-server pods.
+  podLabels: {}
+  # -- Additional annotations to add to the API-server pods.
+  podAnnotations: {}
   image: &apiServerImage
     # -- Override common.image.registry for the API server.
     registry: ""
@@ -63,7 +70,6 @@ apiServer:
       type: RuntimeDefault
   extraEnv: []
   extraEnvFrom: []
-  extraLabels: {}
   probes:
     startup:
       failureThreshold: 30
@@ -154,7 +160,14 @@ initializer:
   # and `helm upgrade` are executed with `--wait` flag. See <https://github.com/helm/helm/issues/10555>.
   # Note that without hooks, `helm upgrade` may fail due to Job fields being immutable.
   noHelmHook: false
+  # -- Additional labels to add to the initializer Job resource.
+  labels: {}
+  # -- Additional annotations to add to the initializer Job resource.
   annotations: {}
+  # -- Additional labels to add to the initializer pods.
+  podLabels: {}
+  # -- Additional annotations to add to the initializer pods.
+  podAnnotations: {}
   image: *apiServerImage
   command: []
   args: []
@@ -197,7 +210,14 @@ frontend:
     # -- The deployment strategy to use.
     strategy:
       type: RollingUpdate
+  # -- Additional labels to add to the frontend Deployment resource.
+  labels: {}
+  # -- Additional annotations to add to the frontend Deployment resource.
   annotations: {}
+  # -- Additional labels to add to the frontend pods.
+  podLabels: {}
+  # -- Additional annotations to add to the frontend pods.
+  podAnnotations: {}
   image:
     # -- Override common.image.registry for the API frontend.
     registry: ""
@@ -227,7 +247,6 @@ frontend:
       type: RuntimeDefault
   extraEnv: []
   extraEnvFrom: []
-  extraLabels: {}
   probes:
     liveness:
       failureThreshold: 3


### PR DESCRIPTION
Split annotations and labels into Job-level and Pod-template-level to allow independent customization. Add support for custom labels on both Job and Pod. Wrap labels blocks in conditional to prevent rendering empty labels fields.
