### PR TITLE
fix(hyades): expose api-server management port on Service

### DIFF
--- a/charts/hyades/README.md
+++ b/charts/hyades/README.md
@@ -73,6 +73,7 @@ v2, or be ready to migrate when v2 is released.
 | apiServer.resources.requests.memory | string | `"2Gi"` |  |
 | apiServer.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context of the Container. |
 | apiServer.service.annotations | object | `{}` |  |
+| apiServer.service.managementPort | int | `9000` |  |
 | apiServer.service.nodePort | string | `nil` |  |
 | apiServer.service.port | int | `8080` |  |
 | apiServer.service.type | string | `"ClusterIP"` |  |

--- a/charts/hyades/templates/api-server/service.yaml
+++ b/charts/hyades/templates/api-server/service.yaml
@@ -18,5 +18,8 @@ spec:
     {{- with .Values.apiServer.service.nodePort }}
     nodePort: {{ . }}
     {{- end }}
+  - name: management
+    port: {{ .Values.apiServer.service.managementPort }}
+    targetPort: management
   selector: {{- include "hyades.apiServerSelectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/hyades/values.yaml
+++ b/charts/hyades/values.yaml
@@ -87,6 +87,7 @@ apiServer:
     type: ClusterIP
     nodePort: ~
     port: 8080
+    managementPort: 9000
     annotations: {}
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
The api-server `ServiceMonitor` scrapes the endpoint named `management`:

```yaml
endpoints:
- port: management
  path: /metrics
```

but the api-server `Service` only publishes the `web` port. Because the `Service` has no port named `management`, the Prometheus Operator generates **no scrape target** for it, so the api-server metrics are never collected; even with `apiServer.serviceMonitor.enabled: true`.

The api-server container already exposes the management port (`containerPort: 9000`, used by the health probes), it just was not surfaced on the `Service`.

## Change

- Add the `management` port to the api-server `Service`, with `targetPort: management` so it resolves to container port 9000 by name (mirroring how `web` is wired).
- Make the port configurable via `apiServer.service.managementPort` (default `9000`).

## Verification

`helm template` with `apiServer.serviceMonitor.enabled=true` now renders both ports on the Service, matching the ServiceMonitor endpoint:

```yaml
spec:
  ports:
  - name: web
    port: 8080
    targetPort: web
  - name: management
    port: 9000
    targetPort: management
```

`helm lint` and `ct lint --config ct.yaml` both pass. README regenerated with `helm-docs`.