### PR TITLE
fix: add global property to dependency-track values.schema.json

### DIFF
--- a/charts/dependency-track/values.schema.json
+++ b/charts/dependency-track/values.schema.json
@@ -4,6 +4,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "global": {
+      "type": "object",
+      "description": "Builtin Helm value; required so the chart validates when used as a subchart (ref helm/helm#10392)"
+    },
     "nameOverride": {
       "type": "string"
     },


### PR DESCRIPTION
## What

Adds a `global` object property to `charts/dependency-track/values.schema.json`.

## Why

I'm using sub charts to keep ArgoCD relativly clean.... So when doing so I get an alert due to the schema.

The chart's root schema sets `additionalProperties: false`. Helm propagates `global` into every subchart's `.Values`, so when this chart is consumed as a dependency the injected `global` key fails schema validation. Declaring `global` lets the chart validate as a subchart.

ref [helm/helm#10392](https://github.com/helm/helm/issues/10392)
