### PR TITLE
allow additionalProperties at the root level of values

### DIFF
--- a/charts/dependency-track/values.schema.json
+++ b/charts/dependency-track/values.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Values",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "global": {
       "type": "object",


### PR DESCRIPTION
This change allows additionalProperties in the root level of the values.yaml. This is necessary, so the chart can be used as a subchart with other components.