### PR TITLE
Pin version of v4-migrator image

### DIFF
--- a/charts/dependency-track/MIGRATION.md
+++ b/charts/dependency-track/MIGRATION.md
@@ -25,6 +25,7 @@ migration:
     jdbcUrl: # Required: Configure the target database URL
     existingSecret: # Required: Configure the target database credentials
   image: # Optionally adjust the migrator image here
+    tag: "5.0.4" # Set this to the target v5 version that you plan to deploy
  
 apiServer:
   replicaCount: 0  # Recommended

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -27,7 +27,7 @@ migration:
   image:
     registry: ghcr.io
     repository: dependencytrack/v4-migrator
-    tag: "5-snapshot"
+    tag: "5.0.4"
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
`5-snapshot` may contain schema changes that the latest stable 5.x version doesn't yet have and/or support.