### PR TITLE
Allow setting annotations for initializer Job

### DIFF
--- a/charts/dependency-track/README.md
+++ b/charts/dependency-track/README.md
@@ -148,7 +148,8 @@ Do note however:
 | apiServer.image.repository | string | `"dependencytrack/apiserver"` | Repository of the `apiserver` image. |
 | apiServer.image.tag | string | `""` | Tag name or `sha256:<digest>`. Defaults to the chart's `appVersion`. |
 | apiServer.initContainers | list | `[]` |  |
-| apiServer.initializer | object | `{"backoffLimit":3,"enabled":false,"initContainers":[],"nodeSelector":{},"podAnnotations":{},"resources":{"limits":{"memory":"256Mi"},"requests":{"cpu":"150m","memory":"256Mi"}},"tolerations":[]}` | Initializer Job settings. Runs DT's init tasks (migrations, default-object seeding, partition maintenance) as a pre-install/pre-upgrade Helm hook instead of in every starting api-server pod. Requires `database.existingSecret`. See the Initializer section in the README. |
+| apiServer.initializer | object | `{"annotations":{},"backoffLimit":3,"enabled":false,"initContainers":[],"nodeSelector":{},"podAnnotations":{},"resources":{"limits":{"memory":"256Mi"},"requests":{"cpu":"150m","memory":"256Mi"}},"tolerations":[]}` | Initializer Job settings. Runs DT's init tasks (migrations, default-object seeding, partition maintenance) as a pre-install/pre-upgrade Helm hook instead of in every starting api-server pod. Requires `database.existingSecret`. See the Initializer section in the README. |
+| apiServer.initializer.annotations | object | `{}` | Annotations on the initializer Job itself. Merged with (and may override) the chart-managed `helm.sh/*` hook annotations. |
 | apiServer.initializer.nodeSelector | object | `{}` | Node selector for the initializer Job's pod. Replaces the root-level `nodeSelector` when set to a non-empty value. |
 | apiServer.initializer.tolerations | list | `[]` | Tolerations for the initializer Job's pod. Replaces the root-level `tolerations` when set to a non-empty value. |
 | apiServer.podAnnotations | object | `{}` |  |

--- a/charts/dependency-track/templates/api-server/initializer-job.yaml
+++ b/charts/dependency-track/templates/api-server/initializer-job.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "dependencytrack.componentLabels" (dict "ctx" . "component" "initializer" "role" "") | nindent 4 }}
   {{- $hookAnnotations := dict "helm.sh/hook" "pre-install,pre-upgrade" "helm.sh/hook-weight" "0" "helm.sh/hook-delete-policy" "before-hook-creation" }}
-  {{- $annotations := mergeOverwrite $hookAnnotations .Values.apiServer.initializer.annotations }}
+  {{- $annotations := mergeOverwrite $hookAnnotations (.Values.apiServer.initializer.annotations | default dict) }}
   annotations: {{- toYaml $annotations | nindent 4 }}
 spec:
   backoffLimit: {{ .Values.apiServer.initializer.backoffLimit }}

--- a/charts/dependency-track/templates/api-server/initializer-job.yaml
+++ b/charts/dependency-track/templates/api-server/initializer-job.yaml
@@ -7,10 +7,9 @@ metadata:
   name: {{ include "dependencytrack.componentFullname" (dict "ctx" . "suffix" "initializer") }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "dependencytrack.componentLabels" (dict "ctx" . "component" "initializer" "role" "") | nindent 4 }}
-  annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+  {{- $hookAnnotations := dict "helm.sh/hook" "pre-install,pre-upgrade" "helm.sh/hook-weight" "0" "helm.sh/hook-delete-policy" "before-hook-creation" }}
+  {{- $annotations := mergeOverwrite $hookAnnotations .Values.apiServer.initializer.annotations }}
+  annotations: {{- toYaml $annotations | nindent 4 }}
 spec:
   backoffLimit: {{ .Values.apiServer.initializer.backoffLimit }}
   template:

--- a/charts/dependency-track/tests/initializer_test.yaml
+++ b/charts/dependency-track/tests/initializer_test.yaml
@@ -174,23 +174,6 @@ tests:
       - failedTemplate:
           errorMessage: "apiServer.initializer.enabled requires database.existingSecret.name: the pre-install/pre-upgrade hook Job runs before chart-managed Secrets are created, so provision DB credentials separately."
 
-  - it: enabled - renders exactly the chart's hook annotations when none are set
-    set:
-      apiServer.initializer.enabled: true
-    template: api-server/initializer-job.yaml
-    asserts:
-      - equal:
-          path: metadata.annotations["helm.sh/hook"]
-          value: "pre-install,pre-upgrade"
-      - equal:
-          path: metadata.annotations["helm.sh/hook-weight"]
-          value: "0"
-      - equal:
-          path: metadata.annotations["helm.sh/hook-delete-policy"]
-          value: "before-hook-creation"
-      - notExists:
-          path: metadata.annotations.foo
-
   - it: enabled - user annotations merge with the chart's hook annotations
     set:
       apiServer.initializer.enabled: true
@@ -218,5 +201,3 @@ tests:
       - equal:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
           value: "before-hook-creation,hook-succeeded"
-      - notExists:
-          path: metadata.annotations.foo

--- a/charts/dependency-track/tests/initializer_test.yaml
+++ b/charts/dependency-track/tests/initializer_test.yaml
@@ -173,3 +173,50 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "apiServer.initializer.enabled requires database.existingSecret.name: the pre-install/pre-upgrade hook Job runs before chart-managed Secrets are created, so provision DB credentials separately."
+
+  - it: enabled - renders exactly the chart's hook annotations when none are set
+    set:
+      apiServer.initializer.enabled: true
+    template: api-server/initializer-job.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "pre-install,pre-upgrade"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "0"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: "before-hook-creation"
+      - notExists:
+          path: metadata.annotations.foo
+
+  - it: enabled - user annotations merge with the chart's hook annotations
+    set:
+      apiServer.initializer.enabled: true
+      apiServer.initializer.annotations.foo: bar
+    template: api-server/initializer-job.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations.foo
+          value: bar
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "pre-install,pre-upgrade"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "0"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: "before-hook-creation"
+
+  - it: enabled - user annotations can override chart hook annotations
+    values:
+      - values/initializer-annotations.yaml
+    template: api-server/initializer-job.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: "before-hook-creation,hook-succeeded"
+      - notExists:
+          path: metadata.annotations.foo

--- a/charts/dependency-track/tests/values/initializer-annotations.yaml
+++ b/charts/dependency-track/tests/values/initializer-annotations.yaml
@@ -1,0 +1,13 @@
+database:
+  existingSecret:
+    name: dt-db
+secretManagement:
+  database:
+    kek:
+      existingSecret:
+        name: dt-kek
+apiServer:
+  initializer:
+    enabled: true
+    annotations:
+      helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"

--- a/charts/dependency-track/values.schema.json
+++ b/charts/dependency-track/values.schema.json
@@ -353,6 +353,9 @@
             "backoffLimit": {
               "type": "integer"
             },
+            "annotations": {
+              "type": "object"
+            },
             "resources": {
               "type": "object"
             },

--- a/charts/dependency-track/values.schema.json
+++ b/charts/dependency-track/values.schema.json
@@ -354,7 +354,10 @@
               "type": "integer"
             },
             "annotations": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             },
             "resources": {
               "type": "object"

--- a/charts/dependency-track/values.yaml
+++ b/charts/dependency-track/values.yaml
@@ -255,6 +255,9 @@ apiServer:
   initializer:
     enabled: false
     backoffLimit: 3
+    # -- Annotations on the initializer Job itself.
+    # Merged with (and may override) the chart-managed `helm.sh/*` hook annotations.
+    annotations: {}
     resources:
       requests:
         cpu: 150m


### PR DESCRIPTION
Adds `apiServer.initializer.annotations`, rendered on the `Job`'s metadata alongside the chart-managed `helm.sh/*` hook annotations.

User-provided keys take precedence, so hook settings such as `helm.sh/hook-delete-policy` can be adjusted without editing templates:

```yaml
apiServer:
  initializer:
    enabled: true
    annotations:
      argocd.argoproj.io/hook-delete-policy: HookSucceeded
      helm.sh/hook-delete-policy: "before-hook-creation,hook-succeeded"
```

Defaults are unchanged — with no annotations set, the `Job` renders exactly the three hook annotations as before.

---

_Contribution made with the help of OpenCode._